### PR TITLE
[r=Rocky] Eval context and error messages with source string

### DIFF
--- a/basiclitexpr.go
+++ b/basiclitexpr.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 )
 
-func evalBasicLit(lit *ast.BasicLit) (reflect.Value, bool, error) {
+func evalBasicLit(ctx *Ctx, lit *ast.BasicLit) (reflect.Value, bool, error) {
 	switch lit.Kind {
 	case token.STRING:
 		return reflect.ValueOf(lit.Value[1:len(lit.Value)-1]), true, nil

--- a/binaryexpr.go
+++ b/binaryexpr.go
@@ -7,13 +7,13 @@ import (
 	"go/token"
 )
 
-func evalBinaryExpr(b *ast.BinaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
+func evalBinaryExpr(ctx *Ctx, b *ast.BinaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
 	var xx, yy *[]reflect.Value
 	var xtyped, ytyped bool
-	if xx, xtyped, err = EvalExpr(b.X, env); err != nil {
+	if xx, xtyped, err = EvalExpr(ctx, b.X, env); err != nil {
 		return reflect.Value{}, false, err
 	}
-	if yy, ytyped, err = EvalExpr(b.Y, env); err != nil {
+	if yy, ytyped, err = EvalExpr(ctx, b.Y, env); err != nil {
 		return reflect.Value{}, false, err
 	}
 	rtyped = xtyped || ytyped
@@ -44,15 +44,15 @@ func evalBinaryExpr(b *ast.BinaryExpr, env *Env) (r reflect.Value, rtyped bool, 
 
 	switch x.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		r, err = evalBinaryIntExpr(x, b.Op, y)
+		r, err = evalBinaryIntExpr(ctx, x, b.Op, y)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		r, err = evalBinaryUintExpr(x, b.Op, y)
+		r, err = evalBinaryUintExpr(ctx, x, b.Op, y)
 	case reflect.Float32, reflect.Float64:
-		r, err = evalBinaryFloatExpr(x, b.Op, y)
+		r, err = evalBinaryFloatExpr(ctx, x, b.Op, y)
 	case reflect.Complex64, reflect.Complex128:
-		r, err = evalBinaryComplexExpr(x, b.Op, y)
+		r, err = evalBinaryComplexExpr(ctx, x, b.Op, y)
 	case reflect.String:
-		r, err = evalBinaryStringExpr(x, b.Op, y)
+		r, err = evalBinaryStringExpr(ctx, x, b.Op, y)
 	default:
 		err = ErrInvalidOperands{x, b.Op, y}
 	}
@@ -60,7 +60,7 @@ func evalBinaryExpr(b *ast.BinaryExpr, env *Env) (r reflect.Value, rtyped bool, 
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalBinaryIntExpr(x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
+func evalBinaryIntExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
 	var r int64
 	var err error
 	var b bool
@@ -93,7 +93,7 @@ func evalBinaryIntExpr(x reflect.Value, op token.Token, y reflect.Value) (reflec
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalBinaryUintExpr(x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
+func evalBinaryUintExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
 	var err error
 	var r uint64
 	var b bool
@@ -126,7 +126,7 @@ func evalBinaryUintExpr(x reflect.Value, op token.Token, y reflect.Value) (refle
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalBinaryFloatExpr(x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
+func evalBinaryFloatExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
 	var err error
 	var r float64
 
@@ -145,7 +145,7 @@ func evalBinaryFloatExpr(x reflect.Value, op token.Token, y reflect.Value) (refl
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalBinaryComplexExpr(x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
+func evalBinaryComplexExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
 	var err error
 	var r complex128
 
@@ -161,7 +161,7 @@ func evalBinaryComplexExpr(x reflect.Value, op token.Token, y reflect.Value) (re
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalBinaryStringExpr(x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
+func evalBinaryStringExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Value) (reflect.Value, error) {
 	var err error
 	var r string
 

--- a/callexpr.go
+++ b/callexpr.go
@@ -9,28 +9,28 @@ import (
 	"go/token"
 )
 
-func evalCallExpr(call *ast.CallExpr, env *Env) (*[]reflect.Value, bool, error) {
-	if t, err := evalType(call.Fun, env); err == nil {
-		if v, typed, err := evalCallTypeExpr(t, call, env); err != nil {
+func evalCallExpr(ctx *Ctx, call *ast.CallExpr, env *Env) (*[]reflect.Value, bool, error) {
+	if t, err := evalType(ctx, call.Fun, env); err == nil {
+		if v, typed, err := evalCallTypeExpr(ctx, t, call, env); err != nil {
 			return nil, false, err
 		} else {
 			ret := []reflect.Value{v}
 			return &ret, typed, nil
 		}
-	} else if fun, _, err := EvalExpr(call.Fun, env); err == nil {
-		return evalCallFunExpr((*fun)[0], call, env)
+	} else if fun, _, err := EvalExpr(ctx, call.Fun, env); err == nil {
+		return evalCallFunExpr(ctx, (*fun)[0], call, env)
 	} else {
 		return nil, false, err
 	}
 }
 
-func evalCallTypeExpr(t reflect.Type, call *ast.CallExpr, env *Env) (reflect.Value, bool, error) {
+func evalCallTypeExpr(ctx *Ctx, t reflect.Type, call *ast.CallExpr, env *Env) (reflect.Value, bool, error) {
 	var r reflect.Value
 	if call.Args == nil {
 		return r, false, errors.New(fmt.Sprintf("missing argument to conversion to %v", t))
 	} else if len(call.Args) > 1 {
 		return r, false, errors.New(fmt.Sprintf("too many arguments to conversion to %v", t))
-	} else if arg, typed, err := EvalExpr(call.Args[0], env); err != nil {
+	} else if arg, typed, err := EvalExpr(ctx, call.Args[0], env); err != nil {
 		return r, false, err
 	} else if cast, err := assignableValue((*arg)[0], t, typed); err != nil {
 		return r, false, err
@@ -39,11 +39,11 @@ func evalCallTypeExpr(t reflect.Type, call *ast.CallExpr, env *Env) (reflect.Val
 	}
 }
 
-func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflect.Value, bool, error) {
+func evalCallFunExpr(ctx *Ctx, fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflect.Value, bool, error) {
 	var err error
 	var v *[]reflect.Value
 	var typed bool
-	if v, typed, err = EvalExpr(call.Fun, env); v == nil {
+	if v, typed, err = EvalExpr(ctx, call.Fun, env); v == nil {
 		return nil, false, nil
 	}
 	if err != nil {
@@ -71,7 +71,7 @@ func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflec
 	// Evaluate each arg
 	for i := range call.Args {
 		var err error
-		args[i], atyped[i], err = EvalExpr(call.Args[i], env)
+		args[i], atyped[i], err = EvalExpr(ctx, call.Args[i], env)
 		if err != nil {
 			return nil, false, err
 		}
@@ -79,8 +79,15 @@ func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflec
 
 	_, firstArgIsFun := call.Args[0].(*ast.CallExpr)
 	// Special case for f(g()), where g may return multiple values
+	wasSplat := false
 	if len(call.Args) == 1 && firstArgIsFun {
-		arg   := *(args[0])
+		arg := *(args[0])
+
+		// g := func() {}; h := func() {}; _ = g(h()) is illegal
+		if len(arg) == 0 {
+			return nil, false, ErrMissingValue{at(ctx, call.Args[0])}
+		}
+
 		splat := make([]*[]reflect.Value, len(arg))
 		atyped = make([]bool, len(arg))
 		for i := range arg {
@@ -88,6 +95,7 @@ func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflec
 			atyped[i] = true
 		}
 		args = splat
+		wasSplat = true
 	}
 
 	// Parse args into a slice suitable for calling the function
@@ -100,26 +108,37 @@ func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflec
 	in := make([]reflect.Value, actualNumIn)
 	intyped := make([]bool, actualNumIn)
 
-	if !ftype.IsVariadic() && len(call.Args) == actualNumIn {
+	if !ftype.IsVariadic() && len(args) == actualNumIn {
+		// Standard call
 		for i := range in {
-			arg := *(args[i])
-			if len(arg) > 1 {
-				return nil, false, ErrMultiInSingleContext{arg}
+			var arg reflect.Value;
+			var err error
+
+			// In the case of a splat, we cannot possibly be dealing with multi values here
+			if wasSplat {
+				arg = (*args[i])[0]
+			} else if arg, err = expectSingleValue(ctx, *(args[i]), call.Args[i]); err != nil {
+				return nil, false, err
 			}
-			in[i] = arg[0]
+			in[i] = arg
 			intyped[i] = atyped[i]
 		}
-	} else if ftype.IsVariadic() && actualNumIn-1 <= len(call.Args) {
+	} else if ftype.IsVariadic() && actualNumIn-1 <= len(args) {
+		// Varadic call
 		var i int
 		for i = 0; i < len(in)-1; i += 1 {
-			arg := *(args[i])
-			if len(arg) > 1 {
-				return nil, false, ErrMultiInSingleContext{arg}
+			var arg reflect.Value;
+			var err error
+			if wasSplat {
+				arg = (*args[i])[0]
+			} else if arg, err = expectSingleValue(ctx, *(args[i]), call.Args[i]); err != nil {
+				return nil, false, err
 			}
-			in[i] = arg[0]
+			in[i] = arg
 			intyped[i] = atyped[i]
 		}
-		if i == len(call.Args)-1 && call.Ellipsis != token.NoPos {
+		if i == len(args)-1 && call.Ellipsis != token.NoPos {
+			// Call of form f(first, second, ...others)
 			arg := *(args[i])
 			// Assert this indeed is the ellipsis
 			_ = call.Args[i].(*ast.Ellipsis)
@@ -128,17 +147,17 @@ func evalCallFunExpr(fun reflect.Value, call *ast.CallExpr, env *Env) (*[]reflec
 			if err != nil {
 				return nil, false, ErrBadFunArgument{(*v)[0], i, in[i]}
 			}
-		} else if i <= len(call.Args) && call.Ellipsis == token.NoPos {
-			remainingArgs := len(call.Args) - actualNumIn + 1
+		} else if i <= len(args) && call.Ellipsis == token.NoPos {
+			// Call of form f(first, second, third, fourth and so on)
+			remainingArgs := len(args) - actualNumIn + 1
 			in[i] = reflect.MakeSlice(ftype.In(i), remainingArgs, remainingArgs)
 
 			intyped[i] = true
 			etype := in[i].Type().Elem()
-			for j := i; j < len(call.Args); j += 1 {
-				arg := *(args[j])
-				if len(arg) > 1 {
-					return nil, false, ErrMultiInSingleContext{arg}
-				} else if arg, err := assignableValue(arg[0], etype, atyped[j]); err != nil {
+			for j := i; j < len(args); j += 1 {
+				if arg, err := expectSingleValue(ctx, *(args[j]), call.Args[j]); err != nil {
+					return nil, false, err
+				} else if arg, err := assignableValue(arg, etype, atyped[j]); err != nil {
 					return nil, false, ErrBadFunArgument{(*v)[0], j, arg}
 				} else {
 					in[i].Index(j-i).Set(arg)

--- a/callexpr_test.go
+++ b/callexpr_test.go
@@ -36,3 +36,53 @@ func TestFuncCallLogNewWithWrongArgs(t *testing.T) {
 	expectFail(t, "log.New(\"Bob\"), os.Stdout, 0)", env)
 }
 
+func TestFuncCallWithSplatOne(t *testing.T) {
+	env := makeEnv()
+
+	f := func() int { return 1 }
+	g := func(a int) int { return a }
+
+	env.Funcs["f"] = reflect.ValueOf(f)
+	env.Funcs["g"] = reflect.ValueOf(g)
+
+	expr := "g(f())"
+	expected := g(f())
+
+	expectResult(t, expr, env, expected)
+}
+
+func TestFuncCallWithSplatTwo(t *testing.T) {
+	env := makeEnv()
+
+	f := func() (int, int) { return 1, 2 }
+	g := func(a int, b int) int { return a + b }
+
+	env.Funcs["f"] = reflect.ValueOf(f)
+	env.Funcs["g"] = reflect.ValueOf(g)
+
+	expr := "g(f())"
+	expected := g(f())
+
+	expectResult(t, expr, env, expected)
+}
+
+// This test hits a specific case in the implementation where
+// f(g()) is evaluated as args := g(); f(args)
+func TestFuncCallWithMissingValueSplat(t *testing.T) {
+	env := makeEnv()
+
+	env.Funcs["f"] = reflect.ValueOf(func() {})
+	env.Funcs["g"] = reflect.ValueOf(func(int) {})
+
+	expectError(t, "g(f())", env, "f() used as value")
+}
+
+func TestFuncCallWithMissingValue(t *testing.T) {
+	env := makeEnv()
+
+	env.Funcs["f"] = reflect.ValueOf(func() {})
+	env.Funcs["g"] = reflect.ValueOf(func(int, int) {})
+
+	expectError(t, "g(1, f())", env, "f() used as value")
+}
+

--- a/ctx.go
+++ b/ctx.go
@@ -1,0 +1,6 @@
+package interactive
+
+type Ctx struct {
+	Input string
+}
+

--- a/demo/binaryexpr.go
+++ b/demo/binaryexpr.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"reflect"
 	"go/parser"
-    "github.com/0xfaded/go-interactive"
-	"github.com/rocky/ssa-interp/eval"
+	"github.com/0xfaded/go-interactive"
 )
 
 func expectResult(expr string, env *interactive.Env, expected interface{}) {
+	ctx := &interactive.Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		fmt.Printf("Failed to parse expression '%s' (%v)\n", expr, err)
 		return
-	} else if results, _, err := interactive.EvalExpr(e, env); err != nil {
+	} else if results, _, err := interactive.EvalExpr(ctx, e, env); err != nil {
 		fmt.Printf("Error evaluating expression '%s' (%v)\n", expr, err)
 		return
 	} else {

--- a/demo/eval.go
+++ b/demo/eval.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"os"
 
-    "github.com/0xfaded/go-interactive"
+	"github.com/0xfaded/go-interactive"
 )
 
 func main() {

--- a/expr.go
+++ b/expr.go
@@ -8,10 +8,10 @@ import (
 	"go/ast"
 )
 
-func EvalExpr(expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
+func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
 	switch node := expr.(type) {
 	case *ast.Ident:
-		v, typed, err := evalIdentExpr(node, env)
+		v, typed, err := evalIdentExpr(ctx, node, env)
 		if v == nil {
 			return nil, false, err
 		}
@@ -19,16 +19,16 @@ func EvalExpr(expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
 		return &ret, typed, err
 	case *ast.Ellipsis:
 	case *ast.BasicLit:
-		v, typed, err := evalBasicLit(node)
+		v, typed, err := evalBasicLit(ctx, node)
 		return &[]reflect.Value{v}, typed, err
 	case *ast.FuncLit:
 	case *ast.CompositeLit:
-		v, typed, err := evalCompositeLit(node, env)
+		v, typed, err := evalCompositeLit(ctx, node, env)
 		return &[]reflect.Value{*v}, typed, err
 	case *ast.ParenExpr:
-		return EvalExpr(node.X, env)
+		return EvalExpr(ctx, node.X, env)
 	case *ast.SelectorExpr:
-		v, typed, err := evalSelectorExpr(node, env)
+		v, typed, err := evalSelectorExpr(ctx, node, env)
 		if v == nil {
 			return nil, typed, err
 		}
@@ -37,13 +37,13 @@ func EvalExpr(expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
 	case *ast.SliceExpr:
 	case *ast.TypeAssertExpr:
 	case *ast.CallExpr:
-		return evalCallExpr(node, env)
+		return evalCallExpr(ctx, node, env)
 	case *ast.StarExpr:
 	case *ast.UnaryExpr:
-		v, typed, err := evalUnaryExpr(node, env)
+		v, typed, err := evalUnaryExpr(ctx, node, env)
 		return &[]reflect.Value{v}, typed, err
 	case *ast.BinaryExpr:
-		v, typed, err := evalBinaryExpr(node, env)
+		v, typed, err := evalBinaryExpr(ctx, node, env)
 		return &[]reflect.Value{v}, typed, err
 	case *ast.KeyValueExpr:
 	default:
@@ -52,7 +52,7 @@ func EvalExpr(expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
 	return &[]reflect.Value{reflect.ValueOf("Alice")}, true, nil
 }
 
-func evalType(expr ast.Expr, env *Env) (reflect.Type, error) {
+func evalType(ctx *Ctx, expr ast.Expr, env *Env) (reflect.Type, error) {
 	switch node := expr.(type) {
 	case *ast.Ident:
 		if t, ok := env.Types[node.Name]; ok {

--- a/identexpr.go
+++ b/identexpr.go
@@ -8,7 +8,7 @@ import (
 	"go/ast"
 )
 
-func evalIdentExpr(ident *ast.Ident, env *Env) (*reflect.Value, bool, error) {
+func evalIdentExpr(ctx *Ctx, ident *ast.Ident, env *Env) (*reflect.Value, bool, error) {
 	name := ident.Name
 	if name == "nil" {
 		// FIXME: Should this be done first or last?

--- a/interpreter.go
+++ b/interpreter.go
@@ -32,7 +32,7 @@ func Run(env *Env, results *([]interface{})) {
 		//line = "func() {" + line + "}"
 		if expr, err := parser.ParseExpr(line); err != nil {
 			fmt.Printf("parse error: %s\n", err)
-		} else if vals, _, err := EvalExpr(expr, env); err != nil {
+		} else if vals, _, err := EvalExpr(&Ctx{line}, expr, env); err != nil {
 			fmt.Printf("eval error: %s\n", err)
 		} else if vals == nil {
 			fmt.Printf("nil\n")

--- a/selectorexpr.go
+++ b/selectorexpr.go
@@ -8,10 +8,10 @@ import (
 	"go/ast"
 )
 
-func evalSelectorExpr(selector *ast.SelectorExpr, env *Env) (*reflect.Value, bool, error) {
+func evalSelectorExpr(ctx *Ctx, selector *ast.SelectorExpr, env *Env) (*reflect.Value, bool, error) {
 	var err error
 	var x *[]reflect.Value
-	if x, _, err = EvalExpr(selector.X, env); err != nil {
+	if x, _, err = EvalExpr(ctx, selector.X, env); err != nil {
 		return nil, true, err
 	}
 	sel   := selector.Sel.Name
@@ -21,7 +21,7 @@ func evalSelectorExpr(selector *ast.SelectorExpr, env *Env) (*reflect.Value, boo
 	if x0.Kind() == reflect.Ptr {
 		// Special case for handling packages
 		if x0.Type() == reflect.TypeOf(Pkg(nil)) {
-			return evalIdentExpr(selector.Sel, x0.Interface().(Pkg))
+			return evalIdentExpr(ctx, selector.Sel, x0.Interface().(Pkg))
 		} else if !x0.IsNil() && x0.Elem().Kind() == reflect.Struct {
 			x0 = x0.Elem()
 		}

--- a/unaryexpr.go
+++ b/unaryexpr.go
@@ -7,10 +7,10 @@ import (
 	"go/token"
 )
 
-func evalUnaryExpr(b *ast.UnaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
+func evalUnaryExpr(ctx *Ctx, b *ast.UnaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
 	var xx *[]reflect.Value
 	var xtyped bool
-	if xx, xtyped, err = EvalExpr(b.X, env); err != nil {
+	if xx, xtyped, err = EvalExpr(ctx, b.X, env); err != nil {
 		return reflect.Value{}, false, err
 	}
 	rtyped = xtyped
@@ -18,15 +18,15 @@ func evalUnaryExpr(b *ast.UnaryExpr, env *Env) (r reflect.Value, rtyped bool, er
 
 	switch x.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		r, err = evalUnaryIntExpr(x, b.Op)
+		r, err = evalUnaryIntExpr(ctx, x, b.Op)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		r, err = evalUnaryUintExpr(x, b.Op)
+		r, err = evalUnaryUintExpr(ctx, x, b.Op)
 	case reflect.Float32, reflect.Float64:
-		r, err = evalUnaryFloatExpr(x, b.Op)
+		r, err = evalUnaryFloatExpr(ctx, x, b.Op)
 	case reflect.Complex64, reflect.Complex128:
-		r, err = evalUnaryComplexExpr(x, b.Op)
+		r, err = evalUnaryComplexExpr(ctx, x, b.Op)
 	case reflect.String:
-		r, err = evalUnaryStringExpr(x, b.Op)
+		r, err = evalUnaryStringExpr(ctx, x, b.Op)
 	default:
 		err = ErrInvalidOperands{x, b.Op, x}
 	}
@@ -34,7 +34,7 @@ func evalUnaryExpr(b *ast.UnaryExpr, env *Env) (r reflect.Value, rtyped bool, er
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalUnaryIntExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
+func evalUnaryIntExpr(ctx *Ctx, x reflect.Value, op token.Token) (reflect.Value, error) {
 	var r int64
 	var err error
 	// var b bool
@@ -56,7 +56,7 @@ func evalUnaryIntExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalUnaryUintExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
+func evalUnaryUintExpr(ctx *Ctx, x reflect.Value, op token.Token) (reflect.Value, error) {
 	var err error
 	var r uint64
 	var b bool
@@ -76,7 +76,7 @@ func evalUnaryUintExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalUnaryFloatExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
+func evalUnaryFloatExpr(ctx *Ctx, x reflect.Value, op token.Token) (reflect.Value, error) {
 	var err error
 	var r float64
 
@@ -90,7 +90,7 @@ func evalUnaryFloatExpr(x reflect.Value, op token.Token) (reflect.Value, error) 
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalUnaryComplexExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
+func evalUnaryComplexExpr(ctx *Ctx, x reflect.Value, op token.Token) (reflect.Value, error) {
 	var err error
 	var r complex128
 
@@ -102,7 +102,7 @@ func evalUnaryComplexExpr(x reflect.Value, op token.Token) (reflect.Value, error
 }
 
 // Assumes y is assignable to x, panics otherwise
-func evalUnaryStringExpr(x reflect.Value, op token.Token) (reflect.Value, error) {
+func evalUnaryStringExpr(ctx *Ctx, x reflect.Value, op token.Token) (reflect.Value, error) {
 	var err error
 	var r string
 

--- a/util.go
+++ b/util.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+
+	"go/ast"
 )
 
 func assignableValue(x reflect.Value, to reflect.Type, xTyped bool) (reflect.Value, error) {
@@ -95,5 +97,15 @@ func promoteUntypedNumerals(x, y reflect.Value) (reflect.Value, reflect.Value) {
 		}
 	}
 	panic(fmt.Sprintf("runtime: bad untyped numeras %v and %v", x, y))
+}
+
+func expectSingleValue(ctx *Ctx, values []reflect.Value, srcExpr ast.Expr) (reflect.Value, error) {
+	if len(values) == 0 {
+		return reflect.Value{}, ErrMissingValue{at(ctx, srcExpr)}
+	} else if len(values) != 1 {
+		return reflect.Value{}, ErrMultiInSingleContext{at(ctx, srcExpr), values}
+	} else {
+		return values[0], nil
+	}
 }
 


### PR DESCRIPTION
Added an evaluation Ctx which currently only contains the
input source. The Ctx bubbles through the entire computation,
allowing error messages to relate back to source code.

E.g. `g := func() {}; f(g())` -> "g() used as value"

Also fixed bug in function calls of form `f(g())`, where logic was based
on the number of arguments in the expression, 1.

Logic should be based on the number of outputs of `g()`
