### PR TITLE
[r=Rocky]Implemented ast.IndexExpr a[0]; maps unimplemented

### DIFF
--- a/basiclitexpr.go
+++ b/basiclitexpr.go
@@ -12,6 +12,15 @@ import (
 
 func evalBasicLit(ctx *Ctx, lit *ast.BasicLit) (reflect.Value, bool, error) {
 	switch lit.Kind {
+	case token.CHAR:
+		if r, _, tail, err := strconv.UnquoteChar(lit.Value[1:len(lit.Value)-1], '\''); err != nil {
+			return reflect.Value{}, false, ErrBadBasicLit{at(ctx, lit)}
+		} else if tail != "" {
+			// parser.ParseExpr() should raise a syntax error before we get here.
+			panic("go-interactive: bad char lit " + lit.Value)
+		} else {
+			return reflect.ValueOf(r), false, nil
+		}
 	case token.STRING:
 		return reflect.ValueOf(lit.Value[1:len(lit.Value)-1]), true, nil
 	case token.INT:

--- a/expr.go
+++ b/expr.go
@@ -34,6 +34,11 @@ func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env) (*[]reflect.Value, bool, error)
 		}
 		return &[]reflect.Value{*v}, typed, err
 	case *ast.IndexExpr:
+		v, typed, err := evalIndexExpr(ctx, node, env)
+		if v == nil {
+			return nil, typed, err
+		}
+		return &[]reflect.Value{*v}, typed, err
 	case *ast.SliceExpr:
 	case *ast.TypeAssertExpr:
 	case *ast.CallExpr:

--- a/indexexpr.go
+++ b/indexexpr.go
@@ -1,0 +1,89 @@
+package interactive
+
+import (
+	"errors"
+	"reflect"
+
+	"go/ast"
+)
+
+func evalIndexExpr(ctx *Ctx, index *ast.IndexExpr, env *Env) (*reflect.Value, bool, error) {
+	xs, _, err := EvalExpr(ctx, index.X, env)
+	if err != nil {
+		return nil, false, err
+	} else if xs == nil {
+		// XXX temporary error until typed evaluation of nil
+		return nil, false, errors.New("Cannot index nil type")
+	}
+
+	var x reflect.Value
+	if x, err = expectSingleValue(ctx, *xs, index.X); err != nil {
+		return nil, false, err
+	}
+
+	t := x.Type()
+	// Special short hand for array pointers
+	if t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Array {
+		x = x.Elem()
+	}
+
+	switch x.Type().Kind() {
+	// case reflect.Map:
+	case reflect.Array, reflect.Slice, reflect.String:
+		return evalIndexExprInt(ctx, x, index.Index, env)
+	default:
+		return nil, true, ErrInvalidIndexOperation{at(ctx, index), x.Type()}
+	}
+}
+
+// For arrays, slices and strings
+func evalIndexExprInt(ctx *Ctx, x reflect.Value, intExpr ast.Expr, env *Env) (*reflect.Value, bool, error) {
+	if i, err := evalIntIndex(ctx, intExpr, env, x.Type()); err != nil {
+		return nil, false, err
+	} else {
+		v := x.Index(i)
+		return &v, true, nil
+	}
+}
+
+func evalIntIndex(ctx *Ctx, intExpr ast.Expr, env *Env, containerType reflect.Type) (int, error) {
+	if is, typed, err := EvalExpr(ctx, intExpr, env); err != nil {
+		return -1, err
+	} else if is == nil {
+		// XXX temporary error until typed evaluation of nil
+		return -1, errors.New("Cannot index nil type")
+	} else if i, err := expectSingleValue(ctx, *is, intExpr); err != nil {
+		return -1, err
+
+	// XXX This untyped constant conversion is not correct, the index must evaluate exactly
+	// to an integer.
+	// a[2*0.5] is legal, a[2*0.4] is not.
+	//
+	// There is also the constraint that constant expressions such as "abc"[10] must be
+	// in range. Fix both when constant expressions are correctly handled
+	} else if !typed && i.Type().ConvertibleTo(reflect.TypeOf(int(0))) {
+		result := int(i.Convert(reflect.TypeOf(int(0))).Int())
+		if 0 <= result && (containerType.Kind() != reflect.Array || result < containerType.Len()) {
+			return result, nil
+		}
+		return -1, ErrInvalidIndex{at(ctx, intExpr), reflect.ValueOf(result), containerType}
+	} else {
+		var result int
+		switch i.Type().Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			result = int(i.Int())
+			if result >= 0 {
+				return result, nil
+			}
+			return -1, ErrInvalidIndex{at(ctx, intExpr), reflect.ValueOf(result), containerType}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			result = int(i.Uint())
+			if result >= 0 {
+				return result, nil
+			}
+			return -1, ErrInvalidIndex{at(ctx, intExpr), reflect.ValueOf(result), containerType}
+		default:
+			return -1, ErrInvalidIndex{at(ctx, intExpr), i, containerType}
+		}
+	}
+}

--- a/indexexpr_test.go
+++ b/indexexpr_test.go
@@ -1,0 +1,187 @@
+package interactive
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestIndexArray(t *testing.T) {
+	a := [2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expected := a[1]
+	expr := "a[1]"
+
+	expectResult(t, expr, env, expected)
+}
+
+func TestIndexArrayPtr(t *testing.T) {
+	a := &[2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expected := a[1]
+	expr := "a[1]"
+
+	expectResult(t, expr, env, expected)
+}
+
+func TestIndexSlice(t *testing.T) {
+	a := []int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expected := a[1]
+	expr := "a[1]"
+
+	expectResult(t, expr, env, expected)
+}
+
+func TestIndexString(t *testing.T) {
+	a := "ab"
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expected := a[1]
+	expr := "a[1]"
+
+	expectResult(t, expr, env, expected)
+}
+
+func TestIndexArrayConstantOutOfBounds(t *testing.T) {
+	a := [2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[2]"
+	expectError(t, expr, env, "invalid array index 2 (out of bounds for 2-element array)")
+}
+
+func TestIndexArrayNegativeIndex(t *testing.T) {
+	a := [2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[-1]"
+	expectError(t, expr, env, "invalid array index -1 (index must be non-negative)")
+}
+
+func TestIndexArrayNonIntIndex(t *testing.T) {
+	a := [2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := `a["abc"]`
+	expectError(t, expr, env, `non-integer array index "abc"`)
+}
+
+func TestIndexArrayPtrConstantOutOfBounds(t *testing.T) {
+	a := &[2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[2]"
+	expectError(t, expr, env, "invalid array index 2 (out of bounds for 2-element array)")
+}
+
+func TestIndexArrayPtrNegativeIndex(t *testing.T) {
+	a := &[2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[-1]"
+	expectError(t, expr, env, "invalid array index -1 (index must be non-negative)")
+}
+
+func TestIndexArrayPtrNonIntIndex(t *testing.T) {
+	a := &[2]int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := `a["abc"]`
+	expectError(t, expr, env, `non-integer array index "abc"`)
+}
+
+func TestIndexSliceNegativeIndex(t *testing.T) {
+	a := []int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[-1]"
+	expectError(t, expr, env, "invalid slice index -1 (index must be non-negative)")
+}
+
+func TestIndexSliceNonIntIndex(t *testing.T) {
+	a := []int{1, 2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := `a["abc"]`
+	expectError(t, expr, env, `non-integer slice index "abc"`)
+}
+
+/* TODO string constants should error when out of bounds
+func TestIndexStringConstantOutOfBounds(t *testing.T) {
+	a := "ab"
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[2]"
+	expectError(t, expr, env, "invalid array index 2 (out of bounds for 2-byte string)")
+}
+*/
+
+func TestIndexStringNegativeIndex(t *testing.T) {
+	a := "ab"
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[-1]"
+	expectError(t, expr, env, "invalid string index -1 (index must be non-negative)")
+}
+
+func TestIndexStringNonIntIndex(t *testing.T) {
+	a := "ab"
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := `a["abc"]`
+	expectError(t, expr, env, `non-integer string index "abc"`)
+}
+
+func TestInvalidIndexInt(t *testing.T) {
+	a := 1
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[1]"
+	expectError(t, expr, env, `invalid operation: a[1] (index of type int)`)
+}
+
+func TestInvalidIndexSlicePtr(t *testing.T) {
+	a := &[]int{1,2}
+
+	env := makeEnv()
+	env.Vars["a"] = reflect.ValueOf(&a)
+
+	expr := "a[1]"
+	expectError(t, expr, env, `invalid operation: a[1] (index of type *[]int)`)
+}
+


### PR DESCRIPTION
http://golang.org/ref/spec#Index_expressions

known issues.

Constant indicies should fail if expression does not eval to int.
e.g. a[2_0.5] is valid according to spec, whilst a[2_0.4] is not.
Current implementation simply casts untyped floats to an int.

No bounds checks on constant strings.
e.g. "abc"[4] should produce an error (not panic)
