### PR TITLE
Documentation adds. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 pkg/
 src/
-eval
+go-repl
 *.swp
 *.test
 *~

--- a/demo/repl.go
+++ b/demo/repl.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"go/parser"
 	"io"
-	"log"
 	"os"
 	"reflect"
 	"strconv"
@@ -62,10 +61,10 @@ func REPL(env *interactive.Env, results *([]interface{})) {
 			kind := value.Kind().String()
 			fmt.Printf("Kind = %v\n", kind)
 			if kind == "string" {
-				fmt.Printf("Results[%d] = %s\n", exprs,
+				fmt.Printf("results[%d] = %s\n", exprs,
 					strconv.QuoteToASCII(value.String()))
 			} else {
-				fmt.Printf("Results[%d] = %v\n", exprs, (value.Interface()))
+				fmt.Printf("results[%d] = %v\n", exprs, (value.Interface()))
 			}
 			exprs  += 1
 			*results = append(*results, (*vals)[0].Interface())
@@ -79,58 +78,45 @@ func REPL(env *interactive.Env, results *([]interface{})) {
 
 		line, err = readline("go> ", in)
 	}
-	//WriteHistory("data/deleteme.history")
-	// rl.Rl_reset_terminal(term)
 }
 
 func main() {
 	// Set up the environment and then call REPL
 	var vars   map[string] reflect.Value = make(map[string] reflect.Value)
 	var consts map[string] reflect.Value = make(map[string] reflect.Value)
-	var funcs  map[string] reflect.Value = make(map[string] reflect.Value)
 	var types  map[string] reflect.Type  = make(map[string] reflect.Type)
-	{ var x log.Logger; types["Logger"] = reflect.TypeOf(x); }
-	// Constants arent properly implemented, hence the conversion to int64
-	consts["Ldate"] = reflect.ValueOf(int64(log.Ldate))
-	consts["Ltime"] = reflect.ValueOf(int64(log.Ltime))
-	consts["Lmicroseconds"] = reflect.ValueOf(int64(log.Lmicroseconds))
-	consts["Llongfile"] = reflect.ValueOf(int64(log.Llongfile))
-	consts["Lshortfile"] = reflect.ValueOf(int64(log.Lshortfile))
-	consts["LstdFlags"] = reflect.ValueOf(int64(log.LstdFlags))
-	funcs["SetOutput"] = reflect.ValueOf(log.SetOutput)
-	funcs["Println"] = reflect.ValueOf(log.Println)
-	funcs["Panicln"] = reflect.ValueOf(log.Panicln)
-	funcs["New"] = reflect.ValueOf(log.New)
-	funcs["Fatal"] = reflect.ValueOf(log.Fatal)
-	funcs["Flags"] = reflect.ValueOf(log.Flags)
-	funcs["SetFlags"] = reflect.ValueOf(log.SetFlags)
-	funcs["Print"] = reflect.ValueOf(log.Print)
-	funcs["Printf"] = reflect.ValueOf(log.Printf)
-	funcs["Panic"] = reflect.ValueOf(log.Panic)
-	funcs["Panicf"] = reflect.ValueOf(log.Panicf)
-	funcs["Prefix"] = reflect.ValueOf(log.Prefix)
-	funcs["SetPrefix"] = reflect.ValueOf(log.SetPrefix)
-	funcs["Fatalf"] = reflect.ValueOf(log.Fatalf)
-	funcs["Fatalln"] = reflect.ValueOf(log.Fatalln)
+
+	var global_funcs map[string] reflect.Value = make(map[string] reflect.Value)
+	var global_vars map[string]  reflect.Value = make(map[string] reflect.Value)
+
+	// A place to store result values of expressions entered
+	// interactively
+	var results []interface{} = make([] interface{}, 0, 10)
+	global_vars["results"] = reflect.ValueOf(&results)
+	// global_funcs["Result"] = reflect.ValueOf(
+	// 	func(i int) interface{} { return results[i] } )
+
+	// What we have from the fmt package.
+	var fmt_funcs    map[string] reflect.Value = make(map[string] reflect.Value)
+	fmt_funcs["Println"] = reflect.ValueOf(fmt.Println)
+	fmt_funcs["Printf"] = reflect.ValueOf(fmt.Printf)
 
 	type Alice struct {
 		Bob int
 		Secret string
 	}
 
-	var v2 []interface{} = make([] interface{}, 0, 10)
-	vars["Results"] = reflect.ValueOf(&v2)
 	env := interactive.Env {
 		Name:   ".",
-		Vars:   vars,
+		Vars:   global_vars,
 		Consts: make(map[string] reflect.Value),
-		Funcs:  make(map[string] reflect.Value),
+		Funcs:  global_funcs,
 		Types:  map[string] reflect.Type{ "Alice": reflect.TypeOf(Alice{}) },
-		Pkgs:   map[string] interactive.Pkg { "log": &interactive.Env {
-				Name:   "log",
+		Pkgs:   map[string] interactive.Pkg { "fmt": &interactive.Env {
+				Name:   "fmt",
 				Vars:   vars,
 				Consts: consts,
-				Funcs:  funcs,
+				Funcs:  fmt_funcs,
 				Types:  types,
 				Pkgs:   make(map[string] interactive.Pkg),
 			}, "os": &interactive.Env {
@@ -144,6 +130,17 @@ func main() {
 		},
 	}
 
+	fmt.Printf(`=== A simple Go eval REPL ===
+
+Results of expression are stored in variable slice "results".
+Defined functions are: fmt.Println(), fmt.Printf().
+
+Enter expressions to be evaluated at the "go>" prompt.
+
+To see all results, type: "results".
+
+To quit, enter: "quit" or Ctrl-D (EOF).
+`)
 	// And just when you thought we'd never get around to it...
-	REPL(&env, &v2)
+	REPL(&env, &results)
 }

--- a/demo/repl.go
+++ b/demo/repl.go
@@ -130,10 +130,16 @@ func main() {
 		},
 	}
 
+	// Make this truly self-referential
+	global_vars["env"] = reflect.ValueOf(&env)
+
+
 	fmt.Printf(`=== A simple Go eval REPL ===
 
 Results of expression are stored in variable slice "results".
 Defined functions are: fmt.Println(), fmt.Printf().
+
+The environment is stored in global variable "env".
 
 Enter expressions to be evaluated at the "go>" prompt.
 

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 // The start of an eval() function for go.
 
-// The main etry interface is:
+// The main entry point is:
 //  func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env)
 //    (*[]reflect.Value, bool, error)

--- a/doc.go
+++ b/doc.go
@@ -3,3 +3,5 @@
 // The main entry point is:
 //  func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env)
 //    (*[]reflect.Value, bool, error)
+
+package interactive

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+// The start of an eval() function for go.
+
+// The main etry interface is:
+//  func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env)
+//    (*[]reflect.Value, bool, error)


### PR DESCRIPTION
Adds rudimentary help/documentation to doc/repl.go and the library. repl.go starts out with fmt.Printf and fmt.Println while removing the log package.
