### PR TITLE
[r=Rocky]Check unary/binary const expressions

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -34,6 +34,7 @@ type BadExpr struct {
 type Ident struct {
 	*ast.Ident
 	knownType
+	constValue
 }
 
 type Ellipsis struct {
@@ -173,7 +174,6 @@ func (*FuncLit) KnownType() []reflect.Type      { return nil }
 func (*KeyValueExpr) KnownType() []reflect.Type { return nil }
 
 func (*BadExpr) IsConst() bool        { return false }
-func (*Ident) IsConst() bool          { return false }
 func (*Ellipsis) IsConst() bool       { return false }
 func (*FuncLit) IsConst() bool        { return false }
 func (*CompositeLit) IsConst() bool   { return false }
@@ -191,7 +191,6 @@ func (*MapType) IsConst() bool        { return false }
 func (*ChanType) IsConst() bool       { return false }
 
 func (*BadExpr) Const() reflect.Value        { return reflect.Value{} }
-func (*Ident) Const() reflect.Value          { return reflect.Value{} }
 func (*Ellipsis) Const() reflect.Value       { return reflect.Value{} }
 func (*FuncLit) Const() reflect.Value        { return reflect.Value{} }
 func (*CompositeLit) Const() reflect.Value   { return reflect.Value{} }

--- a/ast.go
+++ b/ast.go
@@ -11,7 +11,7 @@ type Expr interface {
 	ast.Expr
 
 	// The type of this expression if known. Certain expr types have special interpretations
-	// Constant expr: a value of nil implies the constant is untyped
+	// Constant expr: a ConstType will be returned if constant is untyped
 	// Ellipsis expr: a single reflect.Type represents the type of all unpacked values
 	KnownType() []reflect.Type
 
@@ -207,3 +207,9 @@ func (*FuncType) Const() reflect.Value       { return reflect.Value{} }
 func (*InterfaceType) Const() reflect.Value  { return reflect.Value{} }
 func (*MapType) Const() reflect.Value        { return reflect.Value{} }
 func (*ChanType) Const() reflect.Value       { return reflect.Value{} }
+
+// Does not assert that c is a valid const value type
+// Should be *BigComplex, bool, or string
+func constValueOf(i interface{}) constValue {
+	return constValue(reflect.ValueOf(i))
+}

--- a/bigcomplex.go
+++ b/bigcomplex.go
@@ -159,19 +159,26 @@ func (z *BigComplex) Equals(other *BigComplex) bool {
 
 func (z *BigComplex) String() string {
 	var s string
-	if z.Re.IsInt() {
-		s += z.Re.Num().String()
-	} else {
-		s += z.Re.FloatString(5)
+	if z.Re.Num().BitLen() != 0 {
+		if z.Re.IsInt() {
+			s += z.Re.Num().String()
+		} else {
+			s += z.Re.FloatString(5)
+		}
 	}
 	if !z.IsReal() {
-		s += "+"
+		if s != "" {
+			s += "+"
+		}
 		if z.Im.IsInt() {
 			s += z.Im.Num().String()
 		} else {
 			s += z.Im.FloatString(5)
 		}
 		s += "i"
+	}
+	if s == "" {
+		s = "0"
 	}
 	return s
 }

--- a/bigcomplex.go
+++ b/bigcomplex.go
@@ -44,6 +44,33 @@ func NewBigRune(n rune) *BigComplex {
 	return z
 }
 
+func NewBigInt64(i int64) *BigComplex {
+	z := new(BigComplex)
+	z.Rat.Denom().SetInt64(1)
+	z.Num().SetInt64(i)
+	return z
+}
+
+func NewBigUint64(u uint64) *BigComplex {
+	z := new(BigComplex)
+	z.Rat.Denom().SetInt64(1)
+	z.Num().SetUint64(u)
+	return z
+}
+
+func NewBigFloat64(f float64) *BigComplex {
+	z := new(BigComplex)
+	z.Rat.SetFloat64(f)
+	return z
+}
+
+func NewBigComplex128(c complex128) *BigComplex {
+	z := new(BigComplex)
+	z.Rat.SetFloat64(real(c))
+	z.Imag.SetFloat64(imag(c))
+	return z
+}
+
 func (z *BigComplex) Add(x, y *BigComplex) *BigComplex {
 	z.Rat.Add(&x.Rat, &y.Rat)
 	z.Imag.Add(&x.Imag, &y.Imag)
@@ -186,10 +213,14 @@ func (z *BigComplex) IsReal() bool {
 	return z.Imag.Num().BitLen() == 0
 }
 
+func (z *BigComplex) Equals(other *BigComplex) bool {
+	return new(BigComplex).Sub(z, other).IsZero()
+}
+
 func (z *BigComplex) String() string {
 	s := z.Rat.FloatString(5)
 	if !z.IsReal() {
-		s += z.Imag.FloatString(5) + "i"
+		s += "+" + z.Imag.FloatString(5) + "i"
 	}
 	return s
 }

--- a/bigcomplex.go
+++ b/bigcomplex.go
@@ -1,0 +1,196 @@
+package interactive
+
+import (
+	"math/big"
+)
+
+// Big complex behaves like a *big.Rat, but has an imaginary component
+// and separate implementation for + - * /
+type BigComplex struct {
+	big.Rat
+	Imag big.Rat
+}
+
+// Use with token.INT ast.BasicLit
+func NewBigInteger(i string) (*BigComplex, bool) {
+	z := new(BigComplex)
+	z.Rat.Denom().SetInt64(1)
+	_, ok := z.Num().SetString(i, 0)
+	return z, ok
+}
+
+// Use with token.FLOAT ast.BasicLit
+func NewBigReal(r string) (*BigComplex, bool) {
+	z := new(BigComplex)
+	_, ok := z.Rat.SetString(r)
+	return z, ok
+}
+
+// Use with token.IMAG ast.BasicLit
+func NewBigImag(i string) (*BigComplex, bool) {
+	z := new(BigComplex)
+	ok := i[len(i)-1] == 'i'
+	if ok {
+		_, ok = z.Imag.SetString(i[:len(i)-1])
+	}
+	return z, ok
+}
+
+// Use with token.CHAR ast.BasicLit
+func NewBigRune(n rune) *BigComplex {
+	z := new(BigComplex)
+	z.Rat.Denom().SetInt64(1)
+	z.Num().SetInt64(int64(n))
+	return z
+}
+
+func (z *BigComplex) Add(x, y *BigComplex) *BigComplex {
+	z.Rat.Add(&x.Rat, &y.Rat)
+	z.Imag.Add(&x.Imag, &y.Imag)
+	return z
+}
+
+func (z *BigComplex) Sub(x, y *BigComplex) *BigComplex {
+	z.Rat.Sub(&x.Rat, &y.Rat)
+	z.Imag.Sub(&x.Imag, &y.Imag)
+	return z
+}
+
+func (z *BigComplex) Mul(x, y *BigComplex) *BigComplex {
+	r := new(big.Rat).Mul(&x.Rat, &y.Rat)
+	r.Sub(r, new(big.Rat).Mul(&x.Imag, &y.Imag))
+
+	i := new(big.Rat).Mul(&x.Rat, &y.Imag)
+	i.Add(i, new(big.Rat).Mul(&x.Imag, &y.Rat))
+
+	z.Rat = *r
+	z.Imag = *i
+	return z
+}
+
+func (z *BigComplex) Quo(x, y *BigComplex) *BigComplex {
+	// a+bi   ac+bd   bc-ad
+	// ---- = ----- + ----- i
+	// c+di   cc+dd   cc+dd
+
+	cc := new(big.Rat).Mul(&y.Rat, &y.Rat)
+	dd := new(big.Rat).Mul(&y.Imag, &y.Imag)
+	ccdd := new(big.Rat).Add(cc, dd)
+
+	ac := new(big.Rat).Mul(&x.Rat, &y.Rat)
+	ad := new(big.Rat).Mul(&x.Rat, &y.Imag)
+	bc := new(big.Rat).Mul(&x.Imag, &y.Rat)
+	bd := new(big.Rat).Mul(&x.Imag, &y.Imag)
+
+	z.Rat.Add(ac, bd)
+	z.Rat.Quo(&z.Rat, ccdd)
+
+	z.Imag.Sub(bc, ad)
+	z.Imag.Quo(&z.Imag, ccdd)
+
+	return z
+}
+
+func (z *BigComplex) IsZero() bool {
+	return z.Rat.Num().BitLen() == 0 && z.Imag.Num().BitLen() == 0
+}
+
+// Return a representation of z truncated to be an int of length bits.
+// Valid values for bits are 8, 16, 32, 64. Result is otherwise undefined
+// If a truncation occurs, the decimal part is dropped and the conversion
+// continues as usual. truncation will be true
+// If an overflow occurs, the result is equivelant to a cast of the form
+// int32(x). overflow will be true.
+func (z *BigComplex) Int(bits int) (_ int64, truncation, overflow bool) {
+	var integer *BigComplex
+	integer, truncation = z.Integer()
+	num := integer.Num()
+
+	// Numerator must fit in bits - 1, with 1 bit left for sign
+	if overflow = num.BitLen() > bits - 1; overflow {
+		var mask uint64 = ^uint64(0) >> uint(64 - bits)
+		num.And(num, new(big.Int).SetUint64(mask))
+	}
+	return num.Int64(), truncation, overflow
+}
+
+// Return a representation of z truncated to be a uint of length bits.
+// Valid values for bits are 0, 8, 16, 32, 64. Result is otherwise undefined
+// If a truncation occurs, the decimal part is dropped and the conversion
+// continues as usual. truncation will be true
+// If an overflow occurs, the result is equivelant to a cast of the form
+// uint32(x). overflow will be true.
+func (z *BigComplex) Uint(bits int) (_ uint64, truncation, overflow bool) {
+	var integer *BigComplex
+	integer, truncation = z.Integer()
+	num := integer.Num()
+
+	var mask uint64 = ^uint64(0) >> uint(64 - bits)
+	if overflow = num.BitLen() > bits; overflow {
+		num.And(num, new(big.Int).SetUint64(mask))
+	}
+
+	r := num.Uint64()
+	if num.Sign() < 0 {
+		overflow = true
+		r = (^r + 1) & mask
+	}
+	return r, truncation, overflow
+}
+
+// Return a representation of z truncated to a float64
+// If a truncation from a complex occurs, the imaginary part is dropped
+// and the conversion continues as usual. truncation will be true
+// exact will be true if the conversion was completed without loss of precision
+func (z *BigComplex) Float64() (f float64, truncation, exact bool) {
+	f, exact = z.Rat.Float64()
+	return f, exact, !z.IsReal()
+}
+
+// Return a complex128 representation of z. 
+// exact will be true if the conversion was completed without loss of precision
+func (z *BigComplex) Complex128() (_ complex128, exact bool) {
+	r, re := z.Rat.Float64()
+	i, ie := z.Imag.Float64()
+	return complex(r, i), re && ie
+}
+
+// Return a representation of z truncated to be a integer value.
+// Second return is true if a truncation occured.
+func (z *BigComplex) Integer() (_ *BigComplex, truncation bool) {
+	if z.IsInteger() {
+		return z, false
+	} else {
+		trunc := new(BigComplex)
+		trunc.SetInt(z.Num())
+		trunc.Num().Div(trunc.Num(), z.Denom())
+		return trunc, true
+	}
+}
+
+// Return a representation of z truncated to be a real value.
+// Second return is true if a truncation occured.
+func (z *BigComplex) Real() (_ *BigComplex, truncation bool) {
+	if z.IsReal() {
+		return z, false
+	} else {
+		return &BigComplex{Rat: z.Rat}, true
+	}
+}
+
+func (z *BigComplex) IsInteger() bool {
+	return z.Rat.IsInt() && z.Imag.Num().BitLen() == 0
+}
+
+func (z *BigComplex) IsReal() bool {
+	return z.Imag.Num().BitLen() == 0
+}
+
+func (z *BigComplex) String() string {
+	s := z.Rat.FloatString(5)
+	if !z.IsReal() {
+		s += z.Imag.FloatString(5) + "i"
+	}
+	return s
+}
+

--- a/bigcomplex.go
+++ b/bigcomplex.go
@@ -218,9 +218,20 @@ func (z *BigComplex) Equals(other *BigComplex) bool {
 }
 
 func (z *BigComplex) String() string {
-	s := z.Rat.FloatString(5)
+	var s string
+	if z.Rat.IsInt() {
+		s += z.Rat.Num().String()
+	} else {
+		s += z.Rat.FloatString(5)
+	}
 	if !z.IsReal() {
-		s += "+" + z.Imag.FloatString(5) + "i"
+		s += "+"
+		if z.Imag.IsInt() {
+			s += z.Imag.Num().String()
+		} else {
+			s += z.Imag.FloatString(5)
+		}
+		s += "i"
 	}
 	return s
 }

--- a/bigcomplex_test.go
+++ b/bigcomplex_test.go
@@ -1,0 +1,81 @@
+package interactive
+
+import (
+	"testing"
+)
+
+func TestIntOverflows(t *testing.T) {
+	expectIntOverflow(t, 8, newBigInt("0x000000fe"), 0xfe)
+	expectIntOverflow(t, 8, newBigInt("-0x000000fe"), 0x02)
+	expectIntOverflow(t, 8, newBigInt("0xfffffffe"), 0xfe)
+	expectIntOverflow(t, 8, newBigInt("-0xfffffffe"), 0x02)
+
+	expectIntOverflow(t, 16, newBigInt("0x0000fffe"), 0xfffe)
+	expectIntOverflow(t, 16, newBigInt("-0x0000fffe"), 0x0002)
+	expectIntOverflow(t, 16, newBigInt("0xfffffffe"), 0xfffe)
+	expectIntOverflow(t, 16, newBigInt("-0xfffffffe"), 0x0002)
+
+	expectIntOverflow(t, 32, newBigInt("0x00fffffffe"), 0xfffffffe)
+	expectIntOverflow(t, 32, newBigInt("-0x00fffffffe"), 0x00000002)
+	expectIntOverflow(t, 32, newBigInt("0xfffffffffe"), 0xfffffffe)
+	expectIntOverflow(t, 32, newBigInt("-0xfffffffffe"), 0x00000002)
+
+	expectIntOverflow(t, 64, newBigInt("0x00fffffffffffffffe"), -0x0000000000000002)
+	expectIntOverflow(t, 64, newBigInt("-0x00fffffffffffffffe"), 0x0000000000000002)
+	expectIntOverflow(t, 64, newBigInt("0xfffffffffffffffffe"), -0x0000000000000002)
+	expectIntOverflow(t, 64, newBigInt("-0xfffffffffffffffffe"), 0x0000000000000002)
+}
+
+func TestUintOverflows(t *testing.T) {
+	expectUintOverflow(t, 8, newBigInt("0x000001fe"), 0xfe)
+	expectUintOverflow(t, 8, newBigInt("0xfffffffe"), 0xfe)
+	expectUintOverflow(t, 8, newBigInt("-0x000000fe"), 0x02)
+	expectUintOverflow(t, 8, newBigInt("-0x000001fe"), 0x02)
+	expectUintOverflow(t, 8, newBigInt("-0xfffffffe"), 0x02)
+
+	expectUintOverflow(t, 16, newBigInt("0x0001fffe"), 0xfffe)
+	expectUintOverflow(t, 16, newBigInt("0xfffffffe"), 0xfffe)
+	expectUintOverflow(t, 16, newBigInt("-0x0000fffe"), 0x0002)
+	expectUintOverflow(t, 16, newBigInt("-0x0001fffe"), 0x0002)
+	expectUintOverflow(t, 16, newBigInt("-0xfffffffe"), 0x0002)
+
+	expectUintOverflow(t, 32, newBigInt("0x01fffffffe"), 0xfffffffe)
+	expectUintOverflow(t, 32, newBigInt("0xfffffffffe"), 0xfffffffe)
+	expectUintOverflow(t, 32, newBigInt("-0x00fffffffe"), 0x00000002)
+	expectUintOverflow(t, 32, newBigInt("-0x01fffffffe"), 0x00000002)
+	expectUintOverflow(t, 32, newBigInt("-0xfffffffffe"), 0x00000002)
+
+	expectUintOverflow(t, 64, newBigInt("0x01fffffffffffffffe"), 0xfffffffffffffffe)
+	expectUintOverflow(t, 64, newBigInt("0xfffffffffffffffffe"), 0xfffffffffffffffe)
+	expectUintOverflow(t, 64, newBigInt("-0x00fffffffffffffffe"), 0x0000000000000002)
+	expectUintOverflow(t, 64, newBigInt("-0x01fffffffffffffffe"), 0x0000000000000002)
+	expectUintOverflow(t, 64, newBigInt("-0xfffffffffffffffffe"), 0x0000000000000002)
+}
+
+func expectIntOverflow(t *testing.T, bits int, c *BigComplex, expected int64) {
+	if result, truncation, overflow := c.Int(bits); truncation {
+		t.Fatalf("Unexpected truncation")
+	} else if !overflow {
+		t.Fatalf("Expected overflow")
+	} else if result != expected {
+		t.Fatalf("Expected %v, got %v\n", expected, result)
+	}
+}
+
+func expectUintOverflow(t *testing.T, bits int, c *BigComplex, expected uint64) {
+	if result, truncation, overflow := c.Uint(bits); truncation {
+		t.Fatalf("Unexpected truncation")
+	} else if !overflow {
+		t.Fatalf("Expected overflow")
+	} else if result != expected {
+		t.Fatalf("Expected %v, got %v\n", expected, result)
+	}
+}
+
+func newBigInt(i string) *BigComplex {
+	if integer, ok := NewBigInteger(i); !ok {
+		panic("Invalid BigInt string '" + i + "'")
+	} else {
+		return integer
+	}
+}

--- a/bigcomplex_test.go
+++ b/bigcomplex_test.go
@@ -73,7 +73,9 @@ func expectUintOverflow(t *testing.T, bits int, c *BigComplex, expected uint64) 
 }
 
 func newBigInt(i string) *BigComplex {
-	if integer, ok := NewBigInteger(i); !ok {
+	integer := new(BigComplex)
+	integer.Re.Denom().SetInt64(1)
+	if _, ok := integer.Re.Num().SetString(i, 0); !ok {
 		panic("Invalid BigInt string '" + i + "'")
 	} else {
 		return integer

--- a/binaryexpr.go
+++ b/binaryexpr.go
@@ -80,7 +80,7 @@ func evalBinaryIntExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Valu
 	case token.NEQ: b = xx != yy; is_bool = true
 	case token.LEQ: b = xx <= yy; is_bool = true
 	case token.GEQ: b = xx >= yy; is_bool = true
-    case token.LSS: b = xx < yy;  is_bool = true
+	case token.LSS: b = xx < yy;  is_bool = true
 	case token.GTR: b = xx > yy;  is_bool = true
 	default: err = ErrInvalidOperands{x, op, y}
 	}
@@ -113,7 +113,7 @@ func evalBinaryUintExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Val
 	case token.NEQ: b = xx != yy; is_bool = true
 	case token.LEQ: b = xx <= yy; is_bool = true
 	case token.GEQ: b = xx >= yy; is_bool = true
-    case token.LSS: b = xx < yy;  is_bool = true
+	case token.LSS: b = xx < yy;  is_bool = true
 	case token.GTR: b = xx > yy;  is_bool = true
 	default: err = ErrInvalidOperands{x, op, y}
 	}
@@ -136,7 +136,7 @@ func evalBinaryFloatExpr(ctx *Ctx, x reflect.Value, op token.Token, y reflect.Va
 	case token.MUL: r = xx * yy
 	case token.QUO: r = xx / yy
 	// case token.EQL: b = xx == yy
-    // case token.LSS: b = xx < yy
+	// case token.LSS: b = xx < yy
 	// case token.GTR: b = xx > yy
 	default: err = ErrInvalidOperands{x, op, y}
 	}

--- a/checkbasiclit.go
+++ b/checkbasiclit.go
@@ -1,9 +1,61 @@
 package interactive
 
 import (
+	"strconv"
+
 	"go/ast"
+	"go/token"
 )
 
 func checkBasicLit(ctx *Ctx, lit *ast.BasicLit, env *Env) (*BasicLit, []error) {
-	return &BasicLit{BasicLit: lit}, nil
+	aexpr := &BasicLit{BasicLit: lit}
+
+	switch lit.Kind {
+	case token.CHAR:
+		if r, _, tail, err := strconv.UnquoteChar(lit.Value[1:len(lit.Value)-1], '\''); err != nil {
+			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+		} else if tail != "" {
+			// parser.ParseExpr() should raise a syntax error before we get here.
+			panic("go-interactive: bad char lit " + lit.Value)
+		} else {
+			aexpr.constValue = constValueOf(NewBigRune(r))
+			aexpr.knownType = knownType{ConstRune}
+			return aexpr, nil
+		}
+	case token.STRING:
+		if str, err := strconv.Unquote(string(lit.Value)); err != nil {
+			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+		} else {
+			aexpr.constValue = constValueOf(str)
+			aexpr.knownType = knownType{ConstString}
+			return aexpr, nil
+		}
+	case token.INT:
+		if i, ok := NewBigInteger(lit.Value); !ok {
+			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+		} else {
+			aexpr.constValue = constValueOf(i)
+			aexpr.knownType = knownType{ConstInt}
+			return aexpr, nil
+		}
+	case token.FLOAT:
+		if f, ok := NewBigReal(lit.Value); !ok {
+			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+		} else {
+			aexpr.constValue = constValueOf(f)
+			aexpr.knownType = knownType{ConstFloat}
+			return aexpr, nil
+		}
+	case token.IMAG:
+		if i, ok := NewBigImag(lit.Value); !ok {
+			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+		} else {
+			aexpr.constValue = constValueOf(i)
+			aexpr.knownType = knownType{ConstComplex}
+			return aexpr, nil
+		}
+	default:
+		return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
+	}
 }
+

--- a/checkbasiclit.go
+++ b/checkbasiclit.go
@@ -18,7 +18,7 @@ func checkBasicLit(ctx *Ctx, lit *ast.BasicLit, env *Env) (*BasicLit, []error) {
 			// parser.ParseExpr() should raise a syntax error before we get here.
 			panic("go-interactive: bad char lit " + lit.Value)
 		} else {
-			aexpr.constValue = constValueOf(NewBigRune(r))
+			aexpr.constValue = constValueOf(NewConstRune(r))
 			aexpr.knownType = knownType{ConstRune}
 			return aexpr, nil
 		}
@@ -31,7 +31,7 @@ func checkBasicLit(ctx *Ctx, lit *ast.BasicLit, env *Env) (*BasicLit, []error) {
 			return aexpr, nil
 		}
 	case token.INT:
-		if i, ok := NewBigInteger(lit.Value); !ok {
+		if i, ok := NewConstInteger(lit.Value); !ok {
 			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
 		} else {
 			aexpr.constValue = constValueOf(i)
@@ -39,7 +39,7 @@ func checkBasicLit(ctx *Ctx, lit *ast.BasicLit, env *Env) (*BasicLit, []error) {
 			return aexpr, nil
 		}
 	case token.FLOAT:
-		if f, ok := NewBigReal(lit.Value); !ok {
+		if f, ok := NewConstFloat(lit.Value); !ok {
 			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
 		} else {
 			aexpr.constValue = constValueOf(f)
@@ -47,7 +47,7 @@ func checkBasicLit(ctx *Ctx, lit *ast.BasicLit, env *Env) (*BasicLit, []error) {
 			return aexpr, nil
 		}
 	case token.IMAG:
-		if i, ok := NewBigImag(lit.Value); !ok {
+		if i, ok := NewConstImag(lit.Value); !ok {
 			return aexpr, []error{ErrBadBasicLit{at(ctx, lit)}}
 		} else {
 			aexpr.constValue = constValueOf(i)

--- a/checkbinaryexpr.go
+++ b/checkbinaryexpr.go
@@ -44,9 +44,10 @@ func checkBinaryExpr(ctx *Ctx, binary *ast.BinaryExpr, env *Env) (aexpr *BinaryE
 	if xa.IsConst() && ya.IsConst() {
 		if xuntyped && yuntyped {
 			yv := ya.Const()
-			if promoted, err := promoteConsts(ctx, xc, yc, ya, yv); err != nil {
-				errs = append(errs, err)
-				errs = append(errs, ErrInvalidBinaryOperation{at(ctx, binary)})
+			xv := xa.Const()
+			var promoted ConstType
+			if promoted, errs = promoteConsts(ctx, xc, yc, xa, ya, xv, yv); errs != nil {
+				errs = append(errs, ErrInvalidBinaryOperation{at(ctx, aexpr)})
 			} else {
 				if isBooleanOp(binary.Op) {
 					aexpr.knownType = []reflect.Type{ConstBool}

--- a/checkbinaryexpr.go
+++ b/checkbinaryexpr.go
@@ -2,6 +2,7 @@ package interactive
 
 import (
 	"go/ast"
+	"go/token"
 )
 
 func checkBinaryExpr(ctx *Ctx, binary *ast.BinaryExpr, env *Env) (aexpr *BinaryExpr, errs []error) {
@@ -14,5 +15,172 @@ func checkBinaryExpr(ctx *Ctx, binary *ast.BinaryExpr, env *Env) (aexpr *BinaryE
 	if aexpr.Y, moreErrs = checkExpr(ctx, binary.Y, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
+
+	if errs == nil {
+		ax := aexpr.X.(Expr)
+		ay := aexpr.Y.(Expr)
+
+		tx := ax.KnownType()
+		ty := ay.KnownType()
+
+		// Check for multi valued expressions. Not much we can do if we find one
+		// TODO check for single values
+
+		// Check for compatible types
+
+		// TODO tx and ty will always have a known type once checker is complete
+		//      This if() is a shim
+		if len(tx) != 1 || len(ty) != 1 {
+			return aexpr, errs
+		}
+
+		cx, okx := tx[0].(ConstType)
+		cy, oky := ty[0].(ConstType)
+		if ax.IsConst() && ay.IsConst() {
+			if okx && oky {
+				if promoted, err := promoteConsts(ctx, cx, cy, ay); err != nil {
+					errs = append(errs, err)
+					errs = append(errs, ErrInvalidBinaryOperation{at(ctx, binary)})
+				} else {
+					aexpr.knownType = knownType{promoted}
+					aexpr.constValue, moreErrs = evalConstBinaryExpr(ctx, aexpr, promoted)
+					if moreErrs != nil {
+						errs = append(errs, moreErrs...)
+					}
+				}
+			}
+		}
+	}
 	return aexpr, errs
 }
+
+// Evaluates a const binary Expr. May return a sensical constValue
+// even if ErrTruncatedConst errors are present
+func evalConstBinaryExpr(ctx *Ctx, constExpr *BinaryExpr, promotedType ConstType) (constValue, []error) {
+	x := constExpr.X.(Expr).Const()
+	y := constExpr.X.(Expr).Const()
+	switch promotedType.(type) {
+	case ConstIntType, ConstRuneType, ConstFloatType, ConstComplexType:
+		xx := x.Interface().(*BigComplex)
+		yy := y.Interface().(*BigComplex)
+		return evalConstBinaryNumericExpr(ctx, constExpr, xx, yy)
+	case ConstStringType:
+		xx := x.String()
+		yy := y.String()
+		return evalConstBinaryStringExpr(ctx, constExpr, xx, yy)
+	case ConstBoolType:
+		xx := x.Bool()
+		yy := y.Bool()
+		return evalConstBinaryBoolExpr(ctx, constExpr, xx, yy)
+	default:
+		// It is possible that both x and y are ConstNil, however no operator is defined, not even ==
+		return constValue{}, []error{ErrInvalidBinaryOperation{at(ctx, constExpr)}}
+	}
+
+}
+
+func evalConstBinaryNumericExpr(ctx *Ctx, constExpr *BinaryExpr, x, y *BigComplex) (constValue, []error) {
+	var errs []error
+	var xx *BigComplex
+	var yy *BigComplex
+
+	switch constExpr.Op {
+	case token.ADD:
+		return constValueOf(NewBigRune(0).Add(x, y)), nil
+	case token.SUB:
+		return constValueOf(NewBigRune(0).Sub(x, y)), nil
+	case token.MUL:
+		return constValueOf(NewBigRune(0).Mul(x, y)), nil
+	case token.QUO:
+		if y.IsZero() {
+			return constValue{}, []error{ErrDivideByZero{at(ctx, constExpr.Y)}}
+		}
+		return constValueOf(NewBigRune(0).Mul(x, y)), nil
+
+	case token.AND, token.OR, token.XOR, token.AND_NOT:
+		var trunc bool
+		if xx, trunc = x.Integer(); trunc {
+			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.X), x})
+		}
+		if yy, trunc = y.Integer(); trunc {
+			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.Y), y})
+		}
+
+		z := NewBigRune(1)
+		switch constExpr.Op {
+		case token.AND:
+			z.Num().And(xx.Num(), yy.Num())
+		case token.OR:
+			z.Num().Or(xx.Num(), yy.Num())
+		case token.XOR:
+			z.Num().Xor(xx.Num(), yy.Num())
+		case token.AND_NOT:
+			z.Num().AndNot(xx.Num(), yy.Num())
+		}
+		return constValueOf(z), errs
+
+	case token.EQL:
+		return constValueOf(x.Rat.Cmp(y.Rat) == 0 && x.Imag.Cmp(y.Imag) == 0), nil
+
+	case token.NEQ, token.LEQ, token.GEQ, token.LSS, token.GTR:
+		var b bool
+		var trunc bool
+		if xx, trunc = x.Real(); trunc {
+			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.X), x})
+		}
+		if yy, trunc = y.Real(); trunc {
+			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.Y), y})
+		}
+		cmp := xx.Rat.Cmp(yy.Rat)
+		switch constExpr.Op {
+		case token.NEQ:
+			b = cmp != 0
+		case token.LEQ:
+			b = cmp == 0 || cmp < 0
+		case token.GEQ:
+			b = cmp == 0 || cmp > 0
+		case token.LSS:
+			b = cmp < 0
+		case token.GTR:
+			b = cmp > 0
+		}
+		return constValueOf(b), errs
+	default:
+		return constValue{}, []error{ErrInvalidBinaryOperation{at(ctx, constExpr)}}
+	}
+}
+
+func evalConstBinaryStringExpr(ctx *Ctx, constExpr *BinaryExpr, x, y string) (constValue, []error) {
+	switch constExpr.Op {
+	case token.ADD:
+		return constValueOf(x + y), nil
+	case token.NEQ:
+		return constValueOf(x != y), nil
+	case token.LEQ:
+		return constValueOf(x <= y), nil
+	case token.GEQ:
+		return constValueOf(x >= y), nil
+	case token.LSS:
+		return constValueOf(x < y), nil
+	case token.GTR:
+		return constValueOf(x > y), nil
+	default:
+		return constValue{}, []error{ErrInvalidBinaryOperation{at(ctx, constExpr)}}
+	}
+}
+
+func evalConstBinaryBoolExpr(ctx *Ctx, constExpr *BinaryExpr, x, y bool) (constValue, []error) {
+	switch constExpr.Op {
+	case token.EQL:
+		return constValueOf(x == y), nil
+	case token.NEQ:
+		return constValueOf(x != y), nil
+	case token. LAND:
+		return constValueOf(x && y), nil
+	case token.LOR:
+		return constValueOf(x || y), nil
+	default:
+		return constValue{}, []error{ErrInvalidBinaryOperation{at(ctx, constExpr)}}
+	}
+}
+

--- a/checkbinaryexpr.go
+++ b/checkbinaryexpr.go
@@ -160,11 +160,8 @@ func evalConstBinaryNumericExpr(ctx *Ctx, constExpr *BinaryExpr, x, y *ConstNumb
 
 	case token.LEQ, token.GEQ, token.LSS, token.GTR:
 		var b bool
-		if x.Type == ConstComplex {
-			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.X), ConstFloat, x})
-		}
-		if y.Type == ConstComplex {
-			errs = append(errs, ErrTruncatedConstant{at(ctx, constExpr.Y), ConstFloat, y})
+		if !(x.Type.IsReal() && y.Type.IsReal()) {
+			return constValue{}, []error{ErrInvalidBinaryOperation{at(ctx, constExpr)}}
 		}
 		cmp := x.Value.Re.Cmp(&y.Value.Re)
 		switch constExpr.Op {

--- a/checkbinaryexpr_test.go
+++ b/checkbinaryexpr_test.go
@@ -22,29 +22,43 @@ import (
 func TestBasicCheckConstBinaryIntegerInteger(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "5 + 2", env, NewBigInt64(5 + 2), ConstInt)
-	expectConst(t, "5 == 5", env, 5 == 5, ConstBool)
+	expectConst(t, "5 % 2", env, NewBigInt64(5 % 2), ConstInt)
+	expectConst(t, "5 & 2", env, NewBigInt64(5 & 2), ConstInt)
+	expectConst(t, "5 == 2", env, 5 == 2, ConstBool)
+	expectConst(t, "5 <= 2", env, 5 <= 2, ConstBool)
 }
 
 func TestBasicCheckConstBinaryIntegerRune(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "1 - 'a'", env, NewBigInt64(1 - 'a'), ConstRune)
+	// Valid
+	expectConst(t, "5 - 'a'", env, NewBigInt64(5 - 'a'), ConstRune)
+	expectConst(t, "5 % 'a'", env, NewBigInt64(5 % 'a'), ConstRune)
+	expectConst(t, "5 | 'a'", env, NewBigInt64(5 | 'a'), ConstRune)
 	expectConst(t, "5 != 'a'", env, 5 != 'a', ConstBool)
+	expectConst(t, "5 >= 'a'", env, 5 >= 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "1 * 1.25", env, NewBigFloat64(1 * 1.25), ConstFloat)
-	expectConst(t, "1 < 1.25", env, 1 < 1.25, ConstBool)
+	// Valid
+	expectConst(t, "5 / 1.25", env, NewBigFloat64(5 / 1.25), ConstFloat)
+	expectConst(t, "5 != 1.5", env, 5 != 1.5, ConstBool)
+	expectConst(t, "5 < 1.5", env, 5 < 1.5, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "5 % 1.0", env, "illegal constant expression: floating-point % operation")
+	expectCheckError(t, "5 | 1.0", env, "illegal constant expression: ideal | ideal")
 }
 
 func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "1 / 4i", env, NewBigComplex128(1 / 4i), ConstComplex)
-	expectConst(t, "1 == 1i", env, 1 == 1i, ConstBool)
+	expectConst(t, "5 * 1.25i", env, NewBigComplex128(5 * 1.25i), ConstComplex)
+	expectConst(t, "5 != 1.5i", env, 5 != 1.5i, ConstBool)
 }
 
 // rune op X tests
@@ -81,18 +95,21 @@ func TestBasicCheckConstBinaryFloatingInteger(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "1.5 + 2", env, NewBigFloat64(1.5 + 2), ConstFloat)
+	expectConst(t, "1.5 == 5", env, 1.5 == 5, ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingRune(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "1.5 - 'a'", env, NewBigFloat64(1.5 - 'a'), ConstFloat)
+	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingFloating(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "2.5 * 1.25", env, NewBigFloat64(2.5 * 1.25), ConstFloat)
+	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingComplex(t *testing.T) {

--- a/checkbinaryexpr_test.go
+++ b/checkbinaryexpr_test.go
@@ -45,7 +45,7 @@ func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
 	env := makeEnv()
 
 	// Valid
-	expectConst(t, "5 / 1.25", env, NewConstFloat64(5 / 1.25), ConstFloat)
+	expectConst(t, "5 / 2.0", env, NewConstFloat64(5 / 2.0), ConstFloat)
 	expectConst(t, "5 != 1.5", env, 5 != 1.5, ConstBool)
 	expectConst(t, "5 < 1.5", env, 5 < 1.5, ConstBool)
 
@@ -57,90 +57,165 @@ func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
 func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "5 * 1.25i", env, NewConstComplex128(5 * 1.25i), ConstComplex)
+	// Vaild
+	expectConst(t, "5 / 1.25i", env, NewConstComplex128(5 / 1.25i), ConstComplex)
 	expectConst(t, "5 != 1.5i", env, 5 != 1.5i, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "5 > 1.5i", env, "illegal constant expression: ideal > ideal")
+	expectCheckError(t, "5 % 2.0i", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "5 & 1.5i", env, "illegal constant expression: ideal & ideal")
 }
 
 // rune op X tests
 func TestBasicCheckConstBinaryRuneInteger(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'a' + 2", env, NewConstRune('a' + 2), ConstRune)
-	expectConst(t, "'a' == 5", env, 'a' == 5, ConstBool)
+	// Valid
+	expectConst(t, "'a' / 2", env, NewConstRune('a' / 2), ConstRune)
+	expectConst(t, "'a' % 2", env, NewConstRune('a' % 2), ConstRune)
+	expectConst(t, "'a' & 2", env, NewConstRune('a' & 2), ConstRune)
+	expectConst(t, "'a' != 2", env, 'a' != 2, ConstBool)
+	expectConst(t, "'a' >= 2", env, 'a' >= 2, ConstBool)
 }
 
 func TestBasicCheckConstBinaryRuneRune(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'a' - 'a'", env, NewConstRune('a' - 'a'), ConstRune)
-	expectConst(t, "'a' != 'a'", env, 'a' != 'a', ConstBool)
+	expectConst(t, "'a' / '\\x04'", env, NewConstRune('a' / '\x04'), ConstRune)
+	expectConst(t, "'a' % '\\x04'", env, NewConstRune('a' % '\x04'), ConstRune)
+	expectConst(t, "'a' ^ '\\x04'", env, NewConstRune('a' ^ '\x04'), ConstRune)
+	expectConst(t, "'a' != '\\x04'", env, 'a' != '\x04', ConstBool)
+	expectConst(t, "'a' > '\\x04'", env, 'a' > '\x04', ConstBool)
 }
 
 func TestBasicCheckConstBinaryRuneFloating(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "'d' * 1.25", env, NewConstFloat64('d' * 1.25), ConstFloat)
 	expectConst(t, "'d' < 1.25", env, 'd' < 1.25, ConstBool)
+	expectConst(t, "'d' != 100.0", env, 'd' != 100.0, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "'d' % 1.0", env, "illegal constant expression: floating-point % operation")
+	expectCheckError(t, "'d' &^ 1.0", env, "illegal constant expression: ideal &^ ideal")
 }
 
 func TestBasicCheckConstBinaryRuneComplex(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "'d' / 4i", env, NewConstComplex128('d' / 4i), ConstComplex)
 	expectConst(t, "'a' == 1i", env, 'a' == 1i, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "'d' > 1.5i", env, "illegal constant expression: ideal > ideal")
+	expectCheckError(t, "'d' % 1.0i", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "'d' ^ 1.0i", env, "illegal constant expression: ideal ^ ideal")
 }
 
 // floating op X tests
 func TestBasicCheckConstBinaryFloatingInteger(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "1.5 + 2", env, NewConstFloat64(1.5 + 2), ConstFloat)
+	expectConst(t, "1.5 < 100", env, 1.5 < 100, ConstBool)
 	expectConst(t, "1.5 == 5", env, 1.5 == 5, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "1.5 % 2", env, "illegal constant expression: floating-point % operation")
+	expectCheckError(t, "1.5 &^ 3", env, "illegal constant expression: ideal &^ ideal")
 }
 
 func TestBasicCheckConstBinaryFloatingRune(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "1.5 - 'a'", env, NewConstFloat64(1.5 - 'a'), ConstFloat)
+	expectConst(t, "1.5 < 'a'", env, 1.5 < 'a', ConstBool)
 	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
+
+	// Invalid
+	expectCheckError(t, "1.5 % 'a'", env, "illegal constant expression: floating-point % operation")
+	expectCheckError(t, "1.5 | 'a'", env, "illegal constant expression: ideal | ideal")
 }
 
 func TestBasicCheckConstBinaryFloatingFloating(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "2.5 * 1.25", env, NewConstFloat64(2.5 * 1.25), ConstFloat)
-	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
+	expectConst(t, "1.5 < 1.25", env, 1.5 < 1.25, ConstBool)
+	expectConst(t, "1.5 == 1.25", env, 1.5 == 1.25, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "1.5 % 1.5", env, "illegal constant expression: floating-point % operation")
+	expectCheckError(t, "1.5 | 1.5", env, "illegal constant expression: ideal | ideal")
 }
 
 func TestBasicCheckConstBinaryFloatingComplex(t *testing.T) {
 	env := makeEnv()
 
+	// Valid
 	expectConst(t, "2.5 / 4i", env, NewConstComplex128(2.5 / 4i), ConstComplex)
+	expectConst(t, "1.5 == 1.25i", env, 1.5 == 1.25i, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "1.5 < 1.25i", env, "illegal constant expression: ideal < ideal")
+	expectCheckError(t, "1.5 % 1.5i", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "1.5 | 1.5i", env, "illegal constant expression: ideal | ideal")
 }
 
 // floating op X tests
 func TestBasicCheckConstBinaryComplexInteger(t *testing.T) {
 	env := makeEnv()
 
+	// Invalid
 	expectConst(t, "2.5i + 2", env, NewConstComplex128(2.5i + 2), ConstComplex)
+	expectConst(t, "2.5i == 2", env, 2.5i == 2, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "2.5i < 2", env, "illegal constant expression: ideal < ideal")
+	expectCheckError(t, "2.5i % 2", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "2.5i | 2", env, "illegal constant expression: ideal | ideal")
 }
 
 func TestBasicCheckConstBinaryComplexRune(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "2.5i - 'a'", env, NewConstComplex128(2.5i - 'a'), ConstComplex)
+	expectConst(t, "2.5i == 'a'", env, 2.5i == 'a', ConstBool)
+
+	// Invalid
+	expectCheckError(t, "2.5i < 'a'", env, "illegal constant expression: ideal < ideal")
+	expectCheckError(t, "2.5i % 'a'", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "2.5i | 'a'", env, "illegal constant expression: ideal | ideal")
 }
 
-func TestBasicCheckConstBinaryComplexComplexing(t *testing.T) {
+func TestBasicCheckConstBinaryComplexFloating(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "2.5i * 1.25", env, NewConstComplex128(2.5i * 1.25), ConstComplex)
+	expectConst(t, "2.5i == 2.0", env, 2.5i == 2.0, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "2.5i < 2.0", env, "illegal constant expression: ideal < ideal")
+	expectCheckError(t, "2.5i % 2.0", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "2.5i | 2.0", env, "illegal constant expression: ideal | ideal")
 }
 
 func TestBasicCheckConstBinaryComplexComplex(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "3i / 4i", env, NewConstComplex128(3i / 4i), ConstComplex)
+	expectConst(t, "2.5i == 2i", env, 2.5i == 2i, ConstBool)
+
+	// Invalid
+	expectCheckError(t, "2.5i < 2i", env, "illegal constant expression: ideal < ideal")
+	expectCheckError(t, "2.5i % 2i", env, "illegal constant expression: ideal % ideal")
+	expectCheckError(t, "2.5i | 2i", env, "illegal constant expression: ideal | ideal")
 }
 
 // bool op X tests

--- a/checkbinaryexpr_test.go
+++ b/checkbinaryexpr_test.go
@@ -1,0 +1,138 @@
+package interactive
+
+import (
+	"testing"
+)
+
+// This file contains three groups of tests.
+// Key: ck. check, ov. overflow, tr. truncation, bo. bad operation
+// 1. Untyped op Untyped. These tests are divided accordingly
+//
+//	    | integer |  rune   |floating | complex |  bool   | string  |   nil   |
+//          +---------+---------+---------|---------+---------+---------+---------+
+// integer  |         |         |         |         |         |         |         |
+// rune     |         |         |         |         |         |         |         |
+// floating |         |         |         |         |         |         |         |
+// complex  |         |         |         |         |         |         |         |
+// bool     |         |         |         |         |         |         |         |
+// string   |         |         |         |         |         |         |         |
+// nil      |         |         |         |         |         |         |         |
+
+// integer op X tests
+func TestBasicCheckConstBinaryIntegerInteger(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "5 + 2", env, NewBigInt64(5 + 2), ConstInt)
+	expectConst(t, "5 == 5", env, 5 == 5, ConstBool)
+}
+
+func TestBasicCheckConstBinaryIntegerRune(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "1 - 'a'", env, NewBigInt64(1 - 'a'), ConstRune)
+	expectConst(t, "5 != 'a'", env, 5 != 'a', ConstBool)
+}
+
+func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "1 * 1.25", env, NewBigFloat64(1 * 1.25), ConstFloat)
+	expectConst(t, "1 < 1.25", env, 1 < 1.25, ConstBool)
+}
+
+func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "1 / 4i", env, NewBigComplex128(1 / 4i), ConstComplex)
+	expectConst(t, "1 == 1i", env, 1 == 1i, ConstBool)
+}
+
+// rune op X tests
+func TestBasicCheckConstBinaryRuneInteger(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "'a' + 2", env, NewBigRune('a' + 2), ConstRune)
+	expectConst(t, "'a' == 5", env, 'a' == 5, ConstBool)
+}
+
+func TestBasicCheckConstBinaryRuneRune(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "'a' - 'a'", env, NewBigRune('a' - 'a'), ConstRune)
+	expectConst(t, "'a' != 'a'", env, 'a' != 'a', ConstBool)
+}
+
+func TestBasicCheckConstBinaryRuneFloating(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "'d' * 1.25", env, NewBigFloat64('d' * 1.25), ConstFloat)
+	expectConst(t, "'d' < 1.25", env, 'd' < 1.25, ConstBool)
+}
+
+func TestBasicCheckConstBinaryRuneComplex(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "'d' / 4i", env, NewBigComplex128('d' / 4i), ConstComplex)
+	expectConst(t, "'a' == 1i", env, 'a' == 1i, ConstBool)
+}
+
+// floating op X tests
+func TestBasicCheckConstBinaryFloatingInteger(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "1.5 + 2", env, NewBigFloat64(1.5 + 2), ConstFloat)
+}
+
+func TestBasicCheckConstBinaryFloatingRune(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "1.5 - 'a'", env, NewBigFloat64(1.5 - 'a'), ConstFloat)
+}
+
+func TestBasicCheckConstBinaryFloatingFloating(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "2.5 * 1.25", env, NewBigFloat64(2.5 * 1.25), ConstFloat)
+}
+
+func TestBasicCheckConstBinaryFloatingComplex(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "2.5 / 4i", env, NewBigComplex128(2.5 / 4i), ConstComplex)
+}
+
+// floating op X tests
+func TestBasicCheckConstBinaryComplexInteger(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "2.5i + 2", env, NewBigComplex128(2.5i + 2), ConstComplex)
+}
+
+func TestBasicCheckConstBinaryComplexRune(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "2.5i - 'a'", env, NewBigComplex128(2.5i - 'a'), ConstComplex)
+}
+
+func TestBasicCheckConstBinaryComplexComplexing(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "2.5i * 1.25", env, NewBigComplex128(2.5i * 1.25), ConstComplex)
+}
+
+func TestBasicCheckConstBinaryComplexComplex(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "3i / 4i", env, NewBigComplex128(3i / 4i), ConstComplex)
+}
+
+// bool op X tests
+func TestBasicCheckConstBinaryBoolBool(t *testing.T) {
+	env := makeEnv()
+
+	expectConst(t, "true == true", env, true, ConstBool)
+	expectConst(t, "true != true", env, false, ConstBool)
+	expectConst(t, "true == false", env, false, ConstBool)
+	expectConst(t, "true != false", env, true, ConstBool)
+}
+

--- a/checkbinaryexpr_test.go
+++ b/checkbinaryexpr_test.go
@@ -67,6 +67,84 @@ func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
 	expectCheckError(t, "5 & 1.5i", env, "illegal constant expression: ideal & ideal")
 }
 
+func TestBasicCheckConstBinaryIntegerBool(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "5 + true", env,
+		"cannot convert true to type int",
+		"invalid operation: 5 + true (mismatched types int and bool)",
+	)
+	expectCheckError(t, "5 % true", env,
+		"cannot convert true to type int",
+		"invalid operation: 5 % true (mismatched types int and bool)",
+	)
+	expectCheckError(t, "5 & true", env,
+		"cannot convert true to type int",
+		"invalid operation: 5 & true (mismatched types int and bool)",
+	)
+	expectCheckError(t, "5 == true", env,
+		"cannot convert true to type int",
+		"invalid operation: 5 == true (mismatched types int and bool)",
+	)
+	expectCheckError(t, "5 < true", env,
+		"cannot convert true to type int",
+		"invalid operation: 5 < true (mismatched types int and bool)",
+	)
+}
+
+func TestBasicCheckConstBinaryIntegerString(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, `5 + "abc"`, env,
+		`cannot convert "abc" to type int`,
+		`invalid operation: 5 + "abc" (mismatched types int and string)`,
+	)
+	expectCheckError(t, `5 % "abc"`, env,
+		`cannot convert "abc" to type int`,
+		`invalid operation: 5 % "abc" (mismatched types int and string)`,
+	)
+	expectCheckError(t, `5 & "abc"`, env,
+		`cannot convert "abc" to type int`,
+		`invalid operation: 5 & "abc" (mismatched types int and string)`,
+	)
+	expectCheckError(t, `5 == "abc"`, env,
+		`cannot convert "abc" to type int`,
+		`invalid operation: 5 == "abc" (mismatched types int and string)`,
+	)
+	expectCheckError(t, `5 < "abc"`, env,
+		`cannot convert "abc" to type int`,
+		`invalid operation: 5 < "abc" (mismatched types int and string)`,
+	)
+}
+
+func TestBasicCheckConstBinaryIntegerNil(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "5 + nil", env,
+		"cannot convert nil to type int",
+		"invalid operation: 5 + nil (mismatched types int and <T>)",
+	)
+	expectCheckError(t, "5 % nil", env,
+		"cannot convert nil to type int",
+		"invalid operation: 5 % nil (mismatched types int and <T>)",
+	)
+	expectCheckError(t, "5 & nil", env,
+		"cannot convert nil to type int",
+		"invalid operation: 5 & nil (mismatched types int and <T>)",
+	)
+	expectCheckError(t, "5 == nil", env,
+		"cannot convert nil to type int",
+		"invalid operation: 5 == nil (mismatched types int and <T>)",
+	)
+	expectCheckError(t, "5 < nil", env,
+		"cannot convert nil to type int",
+		"invalid operation: 5 < nil (mismatched types int and <T>)",
+	)
+}
+
 // rune op X tests
 func TestBasicCheckConstBinaryRuneInteger(t *testing.T) {
 	env := makeEnv()
@@ -113,6 +191,84 @@ func TestBasicCheckConstBinaryRuneComplex(t *testing.T) {
 	expectCheckError(t, "'d' > 1.5i", env, "illegal constant expression: ideal > ideal")
 	expectCheckError(t, "'d' % 1.0i", env, "illegal constant expression: ideal % ideal")
 	expectCheckError(t, "'d' ^ 1.0i", env, "illegal constant expression: ideal ^ ideal")
+}
+
+func TestBasicCheckConstBinaryRuneBool(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "'a' + true", env,
+		"cannot convert true to type rune",
+		"invalid operation: 'a' + true (mismatched types rune and bool)",
+	)
+	expectCheckError(t, "'a' % true", env,
+		"cannot convert true to type rune",
+		"invalid operation: 'a' % true (mismatched types rune and bool)",
+	)
+	expectCheckError(t, "'a' & true", env,
+		"cannot convert true to type rune",
+		"invalid operation: 'a' & true (mismatched types rune and bool)",
+	)
+	expectCheckError(t, "'a' == true", env,
+		"cannot convert true to type rune",
+		"invalid operation: 'a' == true (mismatched types rune and bool)",
+	)
+	expectCheckError(t, "'a' < true", env,
+		"cannot convert true to type rune",
+		"invalid operation: 'a' < true (mismatched types rune and bool)",
+	)
+}
+
+func TestBasicCheckConstBinaryRuneString(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, `'a' + "abc"`, env,
+		`cannot convert "abc" to type rune`,
+		`invalid operation: 'a' + "abc" (mismatched types rune and string)`,
+	)
+	expectCheckError(t, `'a' % "abc"`, env,
+		`cannot convert "abc" to type rune`,
+		`invalid operation: 'a' % "abc" (mismatched types rune and string)`,
+	)
+	expectCheckError(t, `'a' & "abc"`, env,
+		`cannot convert "abc" to type rune`,
+		`invalid operation: 'a' & "abc" (mismatched types rune and string)`,
+	)
+	expectCheckError(t, `'a' == "abc"`, env,
+		`cannot convert "abc" to type rune`,
+		`invalid operation: 'a' == "abc" (mismatched types rune and string)`,
+	)
+	expectCheckError(t, `'a' < "abc"`, env,
+		`cannot convert "abc" to type rune`,
+		`invalid operation: 'a' < "abc" (mismatched types rune and string)`,
+	)
+}
+
+func TestBasicCheckConstBinaryRuneNil(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "'a' + nil", env,
+		"cannot convert nil to type rune",
+		"invalid operation: 'a' + nil (mismatched types rune and <T>)",
+	)
+	expectCheckError(t, "'a' % nil", env,
+		"cannot convert nil to type rune",
+		"invalid operation: 'a' % nil (mismatched types rune and <T>)",
+	)
+	expectCheckError(t, "'a' & nil", env,
+		"cannot convert nil to type rune",
+		"invalid operation: 'a' & nil (mismatched types rune and <T>)",
+	)
+	expectCheckError(t, "'a' == nil", env,
+		"cannot convert nil to type rune",
+		"invalid operation: 'a' == nil (mismatched types rune and <T>)",
+	)
+	expectCheckError(t, "'a' < nil", env,
+		"cannot convert nil to type rune",
+		"invalid operation: 'a' < nil (mismatched types rune and <T>)",
+	)
 }
 
 // floating op X tests
@@ -168,7 +324,85 @@ func TestBasicCheckConstBinaryFloatingComplex(t *testing.T) {
 	expectCheckError(t, "1.5 | 1.5i", env, "illegal constant expression: ideal | ideal")
 }
 
-// floating op X tests
+func TestBasicCheckConstBinaryFloatBool(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "1.0 + true", env,
+		"cannot convert true to type float64",
+		"invalid operation: 1 + true (mismatched types float64 and bool)",
+	)
+	expectCheckError(t, "1.0 % true", env,
+		"cannot convert true to type float64",
+		"invalid operation: 1 % true (mismatched types float64 and bool)",
+	)
+	expectCheckError(t, "1.0 & true", env,
+		"cannot convert true to type float64",
+		"invalid operation: 1 & true (mismatched types float64 and bool)",
+	)
+	expectCheckError(t, "1.0 == true", env,
+		"cannot convert true to type float64",
+		"invalid operation: 1 == true (mismatched types float64 and bool)",
+	)
+	expectCheckError(t, "1.0 < true", env,
+		"cannot convert true to type float64",
+		"invalid operation: 1 < true (mismatched types float64 and bool)",
+	)
+}
+
+func TestBasicCheckConstBinaryFloatString(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, `1.0 + "abc"`, env,
+		`cannot convert "abc" to type float64`,
+		`invalid operation: 1 + "abc" (mismatched types float64 and string)`,
+	)
+	expectCheckError(t, `1.0 % "abc"`, env,
+		`cannot convert "abc" to type float64`,
+		`invalid operation: 1 % "abc" (mismatched types float64 and string)`,
+	)
+	expectCheckError(t, `1.0 & "abc"`, env,
+		`cannot convert "abc" to type float64`,
+		`invalid operation: 1 & "abc" (mismatched types float64 and string)`,
+	)
+	expectCheckError(t, `1.0 == "abc"`, env,
+		`cannot convert "abc" to type float64`,
+		`invalid operation: 1 == "abc" (mismatched types float64 and string)`,
+	)
+	expectCheckError(t, `1.0 < "abc"`, env,
+		`cannot convert "abc" to type float64`,
+		`invalid operation: 1 < "abc" (mismatched types float64 and string)`,
+	)
+}
+
+func TestBasicCheckConstBinaryFloatNil(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "1.0 + nil", env,
+		"cannot convert nil to type float64",
+		"invalid operation: 1 + nil (mismatched types float64 and <T>)",
+	)
+	expectCheckError(t, "1.0 % nil", env,
+		"cannot convert nil to type float64",
+		"invalid operation: 1 % nil (mismatched types float64 and <T>)",
+	)
+	expectCheckError(t, "1.0 & nil", env,
+		"cannot convert nil to type float64",
+		"invalid operation: 1 & nil (mismatched types float64 and <T>)",
+	)
+	expectCheckError(t, "1.0 == nil", env,
+		"cannot convert nil to type float64",
+		"invalid operation: 1 == nil (mismatched types float64 and <T>)",
+	)
+	expectCheckError(t, "1.0 < nil", env,
+		"cannot convert nil to type float64",
+		"invalid operation: 1 < nil (mismatched types float64 and <T>)",
+	)
+}
+
+// complex op X tests
 func TestBasicCheckConstBinaryComplexInteger(t *testing.T) {
 	env := makeEnv()
 
@@ -194,7 +428,7 @@ func TestBasicCheckConstBinaryComplexRune(t *testing.T) {
 	expectCheckError(t, "2.5i | 'a'", env, "illegal constant expression: ideal | ideal")
 }
 
-func TestBasicCheckConstBinaryComplexFloating(t *testing.T) {
+func TestBasicCheckConstBinaryComplexComplexing(t *testing.T) {
 	env := makeEnv()
 
 	expectConst(t, "2.5i * 1.25", env, NewConstComplex128(2.5i * 1.25), ConstComplex)
@@ -216,6 +450,84 @@ func TestBasicCheckConstBinaryComplexComplex(t *testing.T) {
 	expectCheckError(t, "2.5i < 2i", env, "illegal constant expression: ideal < ideal")
 	expectCheckError(t, "2.5i % 2i", env, "illegal constant expression: ideal % ideal")
 	expectCheckError(t, "2.5i | 2i", env, "illegal constant expression: ideal | ideal")
+}
+
+func TestBasicCheckConstBinaryComplexBool(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "1.0i + true", env,
+		"cannot convert true to type complex128",
+		"invalid operation: 1i + true (mismatched types complex128 and bool)",
+	)
+	expectCheckError(t, "1.0i % true", env,
+		"cannot convert true to type complex128",
+		"invalid operation: 1i % true (mismatched types complex128 and bool)",
+	)
+	expectCheckError(t, "1.0i & true", env,
+		"cannot convert true to type complex128",
+		"invalid operation: 1i & true (mismatched types complex128 and bool)",
+	)
+	expectCheckError(t, "1.0i == true", env,
+		"cannot convert true to type complex128",
+		"invalid operation: 1i == true (mismatched types complex128 and bool)",
+	)
+	expectCheckError(t, "1.0i < true", env,
+		"cannot convert true to type complex128",
+		"invalid operation: 1i < true (mismatched types complex128 and bool)",
+	)
+}
+
+func TestBasicCheckConstBinaryComplexString(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, `1.0i + "abc"`, env,
+		`cannot convert "abc" to type complex128`,
+		`invalid operation: 1i + "abc" (mismatched types complex128 and string)`,
+	)
+	expectCheckError(t, `1.0i % "abc"`, env,
+		`cannot convert "abc" to type complex128`,
+		`invalid operation: 1i % "abc" (mismatched types complex128 and string)`,
+	)
+	expectCheckError(t, `1.0i & "abc"`, env,
+		`cannot convert "abc" to type complex128`,
+		`invalid operation: 1i & "abc" (mismatched types complex128 and string)`,
+	)
+	expectCheckError(t, `1.0i == "abc"`, env,
+		`cannot convert "abc" to type complex128`,
+		`invalid operation: 1i == "abc" (mismatched types complex128 and string)`,
+	)
+	expectCheckError(t, `1.0i < "abc"`, env,
+		`cannot convert "abc" to type complex128`,
+		`invalid operation: 1i < "abc" (mismatched types complex128 and string)`,
+	)
+}
+
+func TestBasicCheckConstBinaryComplexNil(t *testing.T) {
+	env := makeEnv()
+
+	// Invalid
+	expectCheckError(t, "1.0i + nil", env,
+		"cannot convert nil to type complex128",
+		"invalid operation: 1i + nil (mismatched types complex128 and <T>)",
+	)
+	expectCheckError(t, "1.0i % nil", env,
+		"cannot convert nil to type complex128",
+		"invalid operation: 1i % nil (mismatched types complex128 and <T>)",
+	)
+	expectCheckError(t, "1.0i & nil", env,
+		"cannot convert nil to type complex128",
+		"invalid operation: 1i & nil (mismatched types complex128 and <T>)",
+	)
+	expectCheckError(t, "1.0i == nil", env,
+		"cannot convert nil to type complex128",
+		"invalid operation: 1i == nil (mismatched types complex128 and <T>)",
+	)
+	expectCheckError(t, "1.0i < nil", env,
+		"cannot convert nil to type complex128",
+		"invalid operation: 1i < nil (mismatched types complex128 and <T>)",
+	)
 }
 
 // bool op X tests

--- a/checkbinaryexpr_test.go
+++ b/checkbinaryexpr_test.go
@@ -23,9 +23,9 @@ func TestBasicCheckConstBinaryIntegerInteger(t *testing.T) {
 	env := makeEnv()
 
 	// Valid
-	expectConst(t, "5 + 2", env, NewBigInt64(5 + 2), ConstInt)
-	expectConst(t, "5 % 2", env, NewBigInt64(5 % 2), ConstInt)
-	expectConst(t, "5 & 2", env, NewBigInt64(5 & 2), ConstInt)
+	expectConst(t, "5 / 2", env, NewConstInt64(5 / 2), ConstInt)
+	expectConst(t, "5 % 2", env, NewConstInt64(5 % 2), ConstInt)
+	expectConst(t, "5 & 2", env, NewConstInt64(5 & 2), ConstInt)
 	expectConst(t, "5 == 2", env, 5 == 2, ConstBool)
 	expectConst(t, "5 <= 2", env, 5 <= 2, ConstBool)
 }
@@ -34,9 +34,9 @@ func TestBasicCheckConstBinaryIntegerRune(t *testing.T) {
 	env := makeEnv()
 
 	// Valid
-	expectConst(t, "5 - 'a'", env, NewBigInt64(5 - 'a'), ConstRune)
-	expectConst(t, "5 % 'a'", env, NewBigInt64(5 % 'a'), ConstRune)
-	expectConst(t, "5 | 'a'", env, NewBigInt64(5 | 'a'), ConstRune)
+	expectConst(t, "5 - 'a'", env, NewConstInt64(5 - 'a'), ConstRune)
+	expectConst(t, "5 % 'a'", env, NewConstInt64(5 % 'a'), ConstRune)
+	expectConst(t, "5 | 'a'", env, NewConstInt64(5 | 'a'), ConstRune)
 	expectConst(t, "5 != 'a'", env, 5 != 'a', ConstBool)
 	expectConst(t, "5 >= 'a'", env, 5 >= 'a', ConstBool)
 }
@@ -45,7 +45,7 @@ func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
 	env := makeEnv()
 
 	// Valid
-	expectConst(t, "5 / 1.25", env, NewBigFloat64(5 / 1.25), ConstFloat)
+	expectConst(t, "5 / 1.25", env, NewConstFloat64(5 / 1.25), ConstFloat)
 	expectConst(t, "5 != 1.5", env, 5 != 1.5, ConstBool)
 	expectConst(t, "5 < 1.5", env, 5 < 1.5, ConstBool)
 
@@ -57,7 +57,7 @@ func TestBasicCheckConstBinaryIntegerFloating(t *testing.T) {
 func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "5 * 1.25i", env, NewBigComplex128(5 * 1.25i), ConstComplex)
+	expectConst(t, "5 * 1.25i", env, NewConstComplex128(5 * 1.25i), ConstComplex)
 	expectConst(t, "5 != 1.5i", env, 5 != 1.5i, ConstBool)
 }
 
@@ -65,28 +65,28 @@ func TestBasicCheckConstBinaryIntegerComplex(t *testing.T) {
 func TestBasicCheckConstBinaryRuneInteger(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'a' + 2", env, NewBigRune('a' + 2), ConstRune)
+	expectConst(t, "'a' + 2", env, NewConstRune('a' + 2), ConstRune)
 	expectConst(t, "'a' == 5", env, 'a' == 5, ConstBool)
 }
 
 func TestBasicCheckConstBinaryRuneRune(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'a' - 'a'", env, NewBigRune('a' - 'a'), ConstRune)
+	expectConst(t, "'a' - 'a'", env, NewConstRune('a' - 'a'), ConstRune)
 	expectConst(t, "'a' != 'a'", env, 'a' != 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryRuneFloating(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'d' * 1.25", env, NewBigFloat64('d' * 1.25), ConstFloat)
+	expectConst(t, "'d' * 1.25", env, NewConstFloat64('d' * 1.25), ConstFloat)
 	expectConst(t, "'d' < 1.25", env, 'd' < 1.25, ConstBool)
 }
 
 func TestBasicCheckConstBinaryRuneComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "'d' / 4i", env, NewBigComplex128('d' / 4i), ConstComplex)
+	expectConst(t, "'d' / 4i", env, NewConstComplex128('d' / 4i), ConstComplex)
 	expectConst(t, "'a' == 1i", env, 'a' == 1i, ConstBool)
 }
 
@@ -94,53 +94,53 @@ func TestBasicCheckConstBinaryRuneComplex(t *testing.T) {
 func TestBasicCheckConstBinaryFloatingInteger(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "1.5 + 2", env, NewBigFloat64(1.5 + 2), ConstFloat)
+	expectConst(t, "1.5 + 2", env, NewConstFloat64(1.5 + 2), ConstFloat)
 	expectConst(t, "1.5 == 5", env, 1.5 == 5, ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingRune(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "1.5 - 'a'", env, NewBigFloat64(1.5 - 'a'), ConstFloat)
+	expectConst(t, "1.5 - 'a'", env, NewConstFloat64(1.5 - 'a'), ConstFloat)
 	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingFloating(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "2.5 * 1.25", env, NewBigFloat64(2.5 * 1.25), ConstFloat)
+	expectConst(t, "2.5 * 1.25", env, NewConstFloat64(2.5 * 1.25), ConstFloat)
 	expectConst(t, "1.5 == 'a'", env, 1.5 == 'a', ConstBool)
 }
 
 func TestBasicCheckConstBinaryFloatingComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "2.5 / 4i", env, NewBigComplex128(2.5 / 4i), ConstComplex)
+	expectConst(t, "2.5 / 4i", env, NewConstComplex128(2.5 / 4i), ConstComplex)
 }
 
 // floating op X tests
 func TestBasicCheckConstBinaryComplexInteger(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "2.5i + 2", env, NewBigComplex128(2.5i + 2), ConstComplex)
+	expectConst(t, "2.5i + 2", env, NewConstComplex128(2.5i + 2), ConstComplex)
 }
 
 func TestBasicCheckConstBinaryComplexRune(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "2.5i - 'a'", env, NewBigComplex128(2.5i - 'a'), ConstComplex)
+	expectConst(t, "2.5i - 'a'", env, NewConstComplex128(2.5i - 'a'), ConstComplex)
 }
 
 func TestBasicCheckConstBinaryComplexComplexing(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "2.5i * 1.25", env, NewBigComplex128(2.5i * 1.25), ConstComplex)
+	expectConst(t, "2.5i * 1.25", env, NewConstComplex128(2.5i * 1.25), ConstComplex)
 }
 
 func TestBasicCheckConstBinaryComplexComplex(t *testing.T) {
 	env := makeEnv()
 
-	expectConst(t, "3i / 4i", env, NewBigComplex128(3i / 4i), ConstComplex)
+	expectConst(t, "3i / 4i", env, NewConstComplex128(3i / 4i), ConstComplex)
 }
 
 // bool op X tests

--- a/checkident.go
+++ b/checkident.go
@@ -1,9 +1,25 @@
 package interactive
 
 import (
+	"reflect"
 	"go/ast"
 )
 
 func checkIdent(ctx *Ctx, ident *ast.Ident, env *Env) (*Ident, []error) {
-	return &Ident{Ident: ident}, nil
+	aexpr := &Ident{Ident: ident}
+	switch aexpr.Name {
+	case "nil":
+		aexpr.constValue = constValueOf(nil)
+		aexpr.knownType = []reflect.Type{ConstNil}
+
+	case "true":
+		aexpr.constValue = constValueOf(true)
+		aexpr.knownType = []reflect.Type{ConstBool}
+
+	case "false":
+		aexpr.constValue = constValueOf(false)
+		aexpr.knownType = []reflect.Type{ConstBool}
+	}
+
+	return aexpr, nil
 }

--- a/checkident.go
+++ b/checkident.go
@@ -9,7 +9,7 @@ func checkIdent(ctx *Ctx, ident *ast.Ident, env *Env) (*Ident, []error) {
 	aexpr := &Ident{Ident: ident}
 	switch aexpr.Name {
 	case "nil":
-		aexpr.constValue = constValueOf(nil)
+		aexpr.constValue = constValueOf(UntypedNil{})
 		aexpr.knownType = []reflect.Type{ConstNil}
 
 	case "true":

--- a/checkunaryexpr.go
+++ b/checkunaryexpr.go
@@ -58,7 +58,7 @@ func evalConstUnaryNumericExpr(ctx *Ctx, constExpr *UnaryExpr, x *BigComplex) (c
 	case token.ADD:
 		return constValueOf(x), nil
 	case token.SUB:
-		zero := NewBigRune(0)
+		zero := new(BigComplex)
 		return constValueOf(zero.Sub(zero, x)), nil
 	default:
 		return constValue{}, []error{ErrInvalidUnaryOperation{at(ctx, constExpr)}}

--- a/checkunaryexpr.go
+++ b/checkunaryexpr.go
@@ -2,6 +2,7 @@ package interactive
 
 import (
 	"go/ast"
+	"go/token"
 )
 
 func checkUnaryExpr(ctx *Ctx, unary *ast.UnaryExpr, env *Env) (aexpr *UnaryExpr, errs []error) {
@@ -11,5 +12,65 @@ func checkUnaryExpr(ctx *Ctx, unary *ast.UnaryExpr, env *Env) (aexpr *UnaryExpr,
 	if aexpr.X, moreErrs = checkExpr(ctx, unary.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
+
+	if errs == nil {
+		a := aexpr.X.(Expr)
+		t := a.KnownType()
+
+		// Check for multi valued expressions. Not much we can do if we find one
+		// TODO check for single values
+
+		// TODO shim
+		if len(t) != 1 {
+			return aexpr, errs
+		}
+
+		if a.IsConst() {
+			if c, ok := t[0].(ConstType); ok {
+				aexpr.constValue, moreErrs = evalConstUnaryExpr(ctx, aexpr, c)
+				if moreErrs != nil {
+					errs = append(errs, moreErrs...)
+				}
+			}
+		}
+	}
 	return aexpr, errs
 }
+
+// Evaluates a const binary Expr. May return a sensical constValue
+// even if ErrTruncatedConst errors are present
+func evalConstUnaryExpr(ctx *Ctx, constExpr *UnaryExpr, resultType ConstType) (constValue, []error) {
+	x := constExpr.X.(Expr).Const()
+	switch resultType.(type) {
+	case ConstIntType, ConstRuneType, ConstFloatType, ConstComplexType:
+		xx := x.Interface().(*BigComplex)
+		return evalConstUnaryNumericExpr(ctx, constExpr, xx)
+	case ConstBoolType:
+		xx := x.Bool()
+		return evalConstUnaryBoolExpr(ctx, constExpr, xx)
+	default:
+		return constValue{}, []error{ErrInvalidUnaryOperation{at(ctx, constExpr)}}
+	}
+}
+
+func evalConstUnaryNumericExpr(ctx *Ctx, constExpr *UnaryExpr, x *BigComplex) (constValue, []error) {
+	switch constExpr.Op {
+	case token.ADD:
+		return constValueOf(x), nil
+	case token.SUB:
+		zero := NewBigRune(0)
+		return constValueOf(zero.Sub(zero, x)), nil
+	default:
+		return constValue{}, []error{ErrInvalidUnaryOperation{at(ctx, constExpr)}}
+	}
+}
+
+func evalConstUnaryBoolExpr(ctx *Ctx, constExpr *UnaryExpr, x bool) (constValue, []error) {
+	switch constExpr.Op {
+	case token.NOT:
+		return constValueOf(!x), nil
+	default:
+		return constValue{}, []error{ErrInvalidUnaryOperation{at(ctx, constExpr)}}
+	}
+}
+

--- a/checkunaryexpr.go
+++ b/checkunaryexpr.go
@@ -43,7 +43,7 @@ func evalConstUnaryExpr(ctx *Ctx, constExpr *UnaryExpr, resultType ConstType) (c
 	x := constExpr.X.(Expr).Const()
 	switch resultType.(type) {
 	case ConstIntType, ConstRuneType, ConstFloatType, ConstComplexType:
-		xx := x.Interface().(*BigComplex)
+		xx := x.Interface().(*ConstNumber)
 		return evalConstUnaryNumericExpr(ctx, constExpr, xx)
 	case ConstBoolType:
 		xx := x.Bool()
@@ -53,12 +53,12 @@ func evalConstUnaryExpr(ctx *Ctx, constExpr *UnaryExpr, resultType ConstType) (c
 	}
 }
 
-func evalConstUnaryNumericExpr(ctx *Ctx, constExpr *UnaryExpr, x *BigComplex) (constValue, []error) {
+func evalConstUnaryNumericExpr(ctx *Ctx, constExpr *UnaryExpr, x *ConstNumber) (constValue, []error) {
 	switch constExpr.Op {
 	case token.ADD:
 		return constValueOf(x), nil
 	case token.SUB:
-		zero := new(BigComplex)
+		zero := &ConstNumber{Type: x.Type}
 		return constValueOf(zero.Sub(zero, x)), nil
 	default:
 		return constValue{}, []error{ErrInvalidUnaryOperation{at(ctx, constExpr)}}

--- a/constnumber.go
+++ b/constnumber.go
@@ -76,7 +76,7 @@ func (z *ConstNumber) String() string {
 		r, _, _ := z.Value.Int(32)
 		return strconv.QuoteRune(rune(r))
 	} else {
-		return z.String()
+		return z.Value.String()
 	}
 }
 

--- a/constnumber.go
+++ b/constnumber.go
@@ -1,5 +1,7 @@
 package interactive
 
+import "strconv"
+
 type ConstNumber struct {
 	Value BigComplex
 	Type ConstType
@@ -69,6 +71,15 @@ func NewConstComplex128(c complex128) *ConstNumber {
 	return z
 }
 
+func (z *ConstNumber) String() string {
+	if z.Type == ConstRune && z.Value.Re.Num().BitLen() <= 32 {
+		r, _, _ := z.Value.Int(32)
+		return strconv.QuoteRune(rune(r))
+	} else {
+		return z.String()
+	}
+}
+
 // Add two ConstNumbers, promoting the type automatically.
 func (z *ConstNumber) Add(x, y *ConstNumber) *ConstNumber {
 	z.Type = promoteConstNumbers(x.Type, y.Type)
@@ -94,7 +105,7 @@ func (z *ConstNumber) Mul(x, y *ConstNumber) *ConstNumber {
 // both operands are of ConstInt, then integer division is performed.
 func (z *ConstNumber) Quo(x, y *ConstNumber) *ConstNumber {
 	z.Type = promoteConstNumbers(x.Type, y.Type)
-	if z.Type == ConstInt {
+	if z.Type.IsIntegral() {
 		z.Value.Re.Num().Div(x.Value.Re.Num(), y.Value.Re.Num())
 	} else {
 		z.Value.Quo(&x.Value, &y.Value)

--- a/constnumber.go
+++ b/constnumber.go
@@ -1,0 +1,144 @@
+package interactive
+
+type ConstNumber struct {
+	Value BigComplex
+	Type ConstType
+}
+
+// Use with token.INT ast.BasicLit
+func NewConstInteger(i string) (*ConstNumber, bool) {
+	z := new(ConstNumber)
+	z.Type = ConstInt
+	z.Value.Re.Denom().SetInt64(1)
+	_, ok := z.Value.Re.Num().SetString(i, 0)
+	return z, ok
+}
+
+// Use with token.FLOAT ast.BasicLit
+func NewConstFloat(r string) (*ConstNumber, bool) {
+	z := new(ConstNumber)
+	z.Type = ConstFloat
+	_, ok := z.Value.Re.SetString(r)
+	return z, ok
+}
+
+// Use with token.IMAG ast.BasicLit
+func NewConstImag(i string) (*ConstNumber, bool) {
+	z := new(ConstNumber)
+	z.Type = ConstComplex
+	ok := i[len(i)-1] == 'i'
+	if ok {
+		_, ok = z.Value.Im.SetString(i[:len(i)-1])
+	}
+	return z, ok
+}
+
+// Use with token.CHAR ast.BasicLit
+func NewConstRune(n rune) *ConstNumber {
+	z := new(ConstNumber)
+	z.Type = ConstRune
+	z.Value.Re.Denom().SetInt64(1)
+	z.Value.Re.Num().SetInt64(int64(n))
+	return z
+}
+
+func NewConstInt64(i int64) *ConstNumber {
+	z := new(ConstNumber)
+	z.Value.Re.Denom().SetInt64(1)
+	z.Value.Re.Num().SetInt64(i)
+	return z
+}
+
+func NewConstUint64(u uint64) *ConstNumber {
+	z := new(ConstNumber)
+	z.Value.Re.Denom().SetInt64(1)
+	z.Value.Re.Num().SetUint64(u)
+	return z
+}
+
+func NewConstFloat64(f float64) *ConstNumber {
+	z := new(ConstNumber)
+	z.Value.Re.SetFloat64(f)
+	return z
+}
+
+func NewConstComplex128(c complex128) *ConstNumber {
+	z := new(ConstNumber)
+	z.Value.Re.SetFloat64(real(c))
+	z.Value.Im.SetFloat64(imag(c))
+	return z
+}
+
+// Add two ConstNumbers, promoting the type automatically.
+func (z *ConstNumber) Add(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Add(&x.Value, &y.Value)
+	return z
+}
+
+// Sub two ConstNumbers, promoting the type automatically.
+func (z *ConstNumber) Sub(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Sub(&x.Value, &y.Value)
+	return z
+}
+
+// Mul two ConstNumbers, promoting the type automatically.
+func (z *ConstNumber) Mul(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Mul(&x.Value, &y.Value)
+	return z
+}
+
+// Divide two ConstNumbers, promoting the type automatically. If
+// both operands are of ConstInt, then integer division is performed.
+func (z *ConstNumber) Quo(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	if z.Type == ConstInt {
+		z.Value.Re.Num().Div(x.Value.Re.Num(), y.Value.Re.Num())
+	} else {
+		z.Value.Quo(&x.Value, &y.Value)
+	}
+	return z
+}
+
+// Compute remainder of two ConstNumbers, promoting the type automatically.
+// Result is undefined if both x and y are not integral types.
+func (z *ConstNumber) Rem(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Re.Num().Rem(x.Value.Re.Num(), y.Value.Re.Num())
+	return z
+}
+
+// Compute and of two ConstNumbers, promoting the type automatically.
+// Result is undefined if both x and y are not integral types.
+func (z *ConstNumber) And(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Re.Num().And(x.Value.Re.Num(), y.Value.Re.Num())
+	return z
+}
+
+// Compute or of two ConstNumbers, promoting the type automatically.
+// Result is undefined if both x and y are not integral types.
+func (z *ConstNumber) Or(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Re.Num().Or(x.Value.Re.Num(), y.Value.Re.Num())
+	return z
+}
+
+// Compute xor of two ConstNumbers, promoting the type automatically.
+// Result is undefined if both x and y are not integral types.
+func (z *ConstNumber) Xor(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Re.Num().Xor(x.Value.Re.Num(), y.Value.Re.Num())
+	return z
+}
+
+// Compute and not of two ConstNumbers, promoting the type automatically.
+// Result is undefined if both x and y are not integral types.
+func (z *ConstNumber) AndNot(x, y *ConstNumber) *ConstNumber {
+	z.Type = promoteConstNumbers(x.Type, y.Type)
+	z.Value.Re.Num().AndNot(x.Value.Re.Num(), y.Value.Re.Num())
+	return z
+}
+

--- a/consttype.go
+++ b/consttype.go
@@ -7,6 +7,7 @@ import "reflect"
 type ConstType interface {
 	reflect.Type
 	IsIntegral() bool
+	IsReal() bool
 }
 
 type ConstIntType struct { reflect.Type }
@@ -42,6 +43,14 @@ func (ConstComplexType) IsIntegral() bool { return false }
 func (ConstStringType) IsIntegral() bool { return false }
 func (ConstNilType) IsIntegral() bool { return false }
 func (ConstBoolType) IsIntegral() bool { return false }
+
+func (ConstIntType) IsReal() bool { return true }
+func (ConstRuneType) IsReal() bool { return true }
+func (ConstFloatType) IsReal() bool { return true }
+func (ConstComplexType) IsReal() bool { return false }
+func (ConstStringType) IsReal() bool { return false }
+func (ConstNilType) IsReal() bool { return false }
+func (ConstBoolType) IsReal() bool { return false }
 
 // Returns the ConstType of a binary, non-boolean, expression invalving const types of
 // x and y.

--- a/consttypes.go
+++ b/consttypes.go
@@ -1,0 +1,152 @@
+package interactive
+
+import "reflect"
+
+// Constant types, should not be used with the reflect package, but
+// can annotate information needed for evaluating const expressions
+type ConstType interface {
+	reflect.Type
+}
+
+type ConstIntType struct { reflect.Type }
+type ConstRuneType struct { reflect.Type }
+type ConstInt32Type struct { reflect.Type }
+type ConstFloatType struct { reflect.Type }
+type ConstComplexType struct { reflect.Type }
+type ConstStringType struct { reflect.Type }
+type ConstNilType struct { reflect.Type }
+type ConstBoolType struct { reflect.Type }
+
+var (
+	ConstInt = ConstIntType { reflect.TypeOf(0) }
+	ConstRune = ConstRuneType { reflect.TypeOf('\000') }
+	ConstFloat = ConstFloatType { reflect.TypeOf(0.0) }
+	ConstComplex = ConstComplexType { reflect.TypeOf(0i) }
+	ConstString = ConstStringType { reflect.TypeOf("") }
+	ConstNil = ConstNilType { nil }
+	ConstBool = ConstBoolType { reflect.TypeOf(false) }
+)
+
+func (ConstIntType) String() string { return "int" }
+func (ConstRuneType) String() string { return "rune" }
+func (ConstFloatType) String() string { return "float64" }
+func (ConstComplexType) String() string { return "complex128" }
+func (ConstStringType) String() string { return "string" }
+func (ConstNilType) String() string { return "<T>" }
+func (ConstBoolType) String() string { return "bool" }
+
+func promoteConsts(ctx *Ctx, x, y ConstType, yexpr Expr, yval reflect.Value) (ConstType, error) {
+	switch x.(type) {
+	case ConstIntType:
+		switch y.(type) {
+		case ConstIntType:
+			return x, nil
+		case ConstRuneType, ConstFloatType, ConstComplexType:
+			return y, nil
+		}
+	case ConstRuneType:
+		switch y.(type) {
+		case ConstIntType, ConstRuneType:
+			return x, nil
+		case ConstFloatType, ConstComplexType:
+			return y, nil
+		}
+	case ConstFloatType:
+		switch y.(type) {
+		case ConstIntType, ConstRuneType, ConstFloatType:
+			return x, nil
+		case ConstComplexType:
+			return y, nil
+		}
+	case ConstComplexType:
+		switch y.(type) {
+		case ConstIntType, ConstRuneType, ConstFloatType, ConstComplexType:
+			return y, nil
+		}
+	case ConstStringType:
+		if _, ok := y.(ConstStringType); ok {
+			return x, nil
+		}
+	case ConstNilType:
+		if _, ok := y.(ConstNilType); ok {
+			return x, nil
+		}
+	case ConstBoolType:
+		if _, ok := y.(ConstBoolType); ok {
+			return x, nil
+		}
+	}
+	return nil, ErrBadConversion{at(ctx, yexpr), y, x, yval}
+}
+
+func convertConstToTyped(ctx *Ctx, from ConstType, c reflect.Value, to reflect.Type, expr Expr) (
+	v reflect.Value, errs []error) {
+
+	v = reflect.New(to).Elem()
+
+	switch from.(type) {
+	case ConstIntType, ConstRuneType, ConstFloatType, ConstComplexType:
+		underlying := c.Interface().(*BigComplex)
+		switch to.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			var errs []error
+			i, truncation, overflow := underlying.Int(to.Bits())
+			if truncation {
+				errs = append(errs, ErrTruncatedConstant{at(ctx, expr), ConstInt, underlying})
+			}
+			if overflow {
+				integer, _ := underlying.Integer()
+				errs = append(errs, ErrOverflowedConstant{at(ctx, expr), from, to, integer})
+			}
+			v.SetInt(i)
+			return v, errs
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			u, truncation, overflow := underlying.Uint(to.Bits())
+			if truncation {
+				errs = append(errs, ErrTruncatedConstant{at(ctx, expr), ConstInt, underlying})
+			}
+			if overflow {
+				integer, _ := underlying.Integer()
+				errs = append(errs, ErrOverflowedConstant{at(ctx, expr), from, to, integer})
+			}
+			v.SetUint(u)
+			return v, errs
+
+		case reflect.Float32, reflect.Float64:
+			f, truncation, _ := underlying.Float64()
+			if truncation {
+				errs = append(errs, ErrTruncatedConstant{at(ctx, expr), ConstFloat, underlying})
+			}
+			v.SetFloat(f)
+			return v, errs
+
+		case reflect.Complex64, reflect.Complex128:
+			cmplx, _ := underlying.Complex128()
+			v.SetComplex(cmplx)
+			return v, errs
+		}
+	case ConstStringType:
+		// Check Kind == String ourselves, as reflect.Value.String() doesn't panic
+		// on non string values
+		if v.Type().Kind() != reflect.String {
+			panic("go-interactive: string constant has wrong underlying type")
+		}
+		v.SetString(c.String())
+
+	case ConstBoolType:
+		v.SetBool(c.Bool())
+
+	case ConstNilType:
+		// Unfortunately there is no reflect.Type.CanNil()
+		switch to.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Interface,
+			reflect.Map, reflect.Ptr, reflect.Slice:
+
+			// v is already nil
+			return v, nil
+		}
+	}
+	return v, []error{ErrBadConversion{at(ctx, expr), from, to, c}}
+}
+

--- a/errors.go
+++ b/errors.go
@@ -48,14 +48,12 @@ type ErrWrongNumberOfArgs struct {
 	numArgs int
 }
 
-
 type ErrMissingValue struct {
 	ErrorContext
 }
 
 type ErrMultiInSingleContext struct {
 	ErrorContext
-	vals []reflect.Value
 }
 
 type ErrArrayIndexOutOfBounds struct {
@@ -72,6 +70,24 @@ type ErrInvalidIndex struct {
 	ErrorContext
 	indexValue reflect.Value
 	containerType reflect.Type
+}
+
+type ErrDivideByZero struct {
+	ErrorContext
+}
+
+type ErrInvalidBinaryOperation struct {
+	ErrorContext
+}
+
+type ErrBadConversion struct {
+	ErrorContext
+	target reflect.Type
+}
+
+type ErrTruncatedConstant struct {
+	ErrorContext
+	constant *BigComplex
 }
 
 type ErrorContext struct {
@@ -160,6 +176,26 @@ func (err ErrMultiInSingleContext) Error() string {
 
 func (err ErrArrayIndexOutOfBounds) Error() string {
 	return fmt.Sprintf("array index %d out of bounds [0:%d]", err.i, err.t.Len())
+}
+
+func (err ErrInvalidBinaryOperation) Error() string {
+	return "ErrInvalidBinaryOperation TODO"
+}
+
+func (err ErrDivideByZero) Error() string {
+	return "division by zero"
+}
+
+func (err ErrBadConversion) Error() string {
+	return "division by zero"
+}
+
+func (err ErrTruncatedConstant) Error() string {
+	if err.constant.IsReal() {
+		return fmt.Sprintf("constant %v truncated to integer", err.constant)
+	} else {
+		return fmt.Sprintf("constant %v truncated to real", err.constant)
+	}
 }
 
 func at(ctx *Ctx, expr ast.Node) ErrorContext {

--- a/errors.go
+++ b/errors.go
@@ -86,12 +86,22 @@ type ErrInvalidUnaryOperation struct {
 
 type ErrBadConversion struct {
 	ErrorContext
-	target reflect.Type
+	to reflect.Type
+	from reflect.Type
+	v reflect.Value
 }
 
 type ErrTruncatedConstant struct {
 	ErrorContext
+	to ConstType
 	constant *BigComplex
+}
+
+type ErrOverflowedConstant struct {
+	ErrorContext
+	from ConstType
+	to reflect.Type
+	constant interface{}
 }
 
 type ErrIllegalConstantExpr struct {
@@ -212,6 +222,10 @@ func (err ErrTruncatedConstant) Error() string {
 	} else {
 		return fmt.Sprintf("constant %v truncated to real", err.constant)
 	}
+}
+
+func (err ErrOverflowedConstant) Error() string {
+	return "ErrOverflowedConstant TODO"
 }
 
 func at(ctx *Ctx, expr ast.Node) ErrorContext {

--- a/errors.go
+++ b/errors.go
@@ -94,7 +94,7 @@ type ErrBadConversion struct {
 type ErrTruncatedConstant struct {
 	ErrorContext
 	to ConstType
-	constant *BigComplex
+	constant *ConstNumber
 }
 
 type ErrOverflowedConstant struct {
@@ -102,10 +102,6 @@ type ErrOverflowedConstant struct {
 	from ConstType
 	to reflect.Type
 	constant interface{}
-}
-
-type ErrIllegalConstantExpr struct {
-	ErrorContext
 }
 
 type ErrorContext struct {
@@ -201,11 +197,12 @@ func (err ErrInvalidUnaryOperation) Error() string {
 }
 
 func (err ErrInvalidBinaryOperation) Error() string {
-	return "ErrInvalidBinaryOperation TODO"
-}
-
-func (err ErrIllegalConstantExpr) Error() string {
-	return "ErrInvalidBinaryOperation TODO"
+	binary := err.ErrorContext.Node.(*BinaryExpr)
+	if binary.Op == token.REM {
+		return "illegal constant expression: floating-point % operation"
+	} else {
+		return "illegal constant expression: ideal | ideal"
+	}
 }
 
 func (err ErrDivideByZero) Error() string {
@@ -217,10 +214,10 @@ func (err ErrBadConversion) Error() string {
 }
 
 func (err ErrTruncatedConstant) Error() string {
-	if err.constant.IsReal() {
-		return fmt.Sprintf("constant %v truncated to integer", err.constant)
-	} else {
+	if err.constant.Type == ConstComplex {
 		return fmt.Sprintf("constant %v truncated to real", err.constant)
+	} else {
+		return fmt.Sprintf("constant %v truncated to integer", err.constant)
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -198,11 +198,21 @@ func (err ErrInvalidUnaryOperation) Error() string {
 
 func (err ErrInvalidBinaryOperation) Error() string {
 	binary := err.ErrorContext.Node.(*BinaryExpr)
-	if binary.Op == token.REM {
-		return "illegal constant expression: floating-point % operation"
-	} else {
-		return "illegal constant expression: ideal | ideal"
+	x := binary.X.(Expr)
+	y := binary.Y.(Expr)
+
+	xn, xnok := x.Const().Interface().(*ConstNumber)
+	yn, ynok := y.Const().Interface().(*ConstNumber)
+	if xnok && ynok {
+		switch binary.Op {
+		case token.REM:
+			if xn.Type.IsReal() && yn.Type.IsReal() {
+				return "illegal constant expression: floating-point % operation"
+			}
+		}
+		return fmt.Sprintf("illegal constant expression: ideal %v ideal", binary.Op)
 	}
+	return "foo"
 }
 
 func (err ErrDivideByZero) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -80,6 +80,10 @@ type ErrInvalidBinaryOperation struct {
 	ErrorContext
 }
 
+type ErrInvalidUnaryOperation struct {
+	ErrorContext
+}
+
 type ErrBadConversion struct {
 	ErrorContext
 	target reflect.Type
@@ -88,6 +92,10 @@ type ErrBadConversion struct {
 type ErrTruncatedConstant struct {
 	ErrorContext
 	constant *BigComplex
+}
+
+type ErrIllegalConstantExpr struct {
+	ErrorContext
 }
 
 type ErrorContext struct {
@@ -178,7 +186,15 @@ func (err ErrArrayIndexOutOfBounds) Error() string {
 	return fmt.Sprintf("array index %d out of bounds [0:%d]", err.i, err.t.Len())
 }
 
+func (err ErrInvalidUnaryOperation) Error() string {
+	return "ErrInvalidUnaryOperation TODO"
+}
+
 func (err ErrInvalidBinaryOperation) Error() string {
+	return "ErrInvalidBinaryOperation TODO"
+}
+
+func (err ErrIllegalConstantExpr) Error() string {
 	return "ErrInvalidBinaryOperation TODO"
 }
 

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -110,6 +110,39 @@ func expectConst(t *testing.T, expr string, env *Env, expected interface{}, expe
 	}
 }
 
+func expectCheckError(t *testing.T, expr string, env *Env, errorString ...string) {
+	ctx := &Ctx{expr}
+	if e, err := parser.ParseExpr(expr); err != nil {
+		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
+	} else if _, errs := checkExpr(ctx, e, env); errs != nil {
+		var i int
+		ok := true
+		for i = 0; i < len(errorString); i += 1 {
+			if i > len(errs) {
+				t.Logf("%d. Expected `%v` missing\n", i, errorString[i])
+				ok = false
+			} else if errorString[i] == errs[i].Error() {
+				t.Logf("%d. Expected `%v` == `%v`\n", i, errorString[i], errs[i])
+			} else {
+				t.Logf("%d. Expected `%v` != `%v`\n", i, errorString[i], errs[i])
+				ok = false
+			}
+		}
+		for ; i < len(errs); i += 1 {
+			t.Logf("%d. Unexpected `%v`\n", i, errs[i])
+			ok = false
+		}
+		if !ok {
+			t.Fatalf("Wrong check errors for expression '%s'", expr)
+		}
+	} else {
+		for i, s := range errorString {
+			t.Logf("%d. Expected `%v` missing\n", i, s)
+		}
+		t.Fatalf("Missing check errors for expression '%s'", expr )
+	}
+}
+
 func makeEnv() *Env {
 	return &Env {
 		Vars: make(map[string] reflect.Value),

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -117,7 +117,7 @@ func expectCheckError(t *testing.T, expr string, env *Env, errorString ...string
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
 	} else if _, errs := checkExpr(ctx, e, env); errs != nil {
 		var i int
-		out := ""
+		out := "\n"
 		ok := true
 		for i = 0; i < len(errorString); i += 1 {
 			if i > len(errs) {

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -81,7 +81,7 @@ func expectFail(t *testing.T, expr string, env *Env) {
 	}
 }
 
-func expectConst(t *testing.T, expr string, env *Env, expected interface{}, expectedType reflect.Type) {
+func expectConst(t *testing.T, expr string, env *Env, expected interface{}, expectedType ConstType) {
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
@@ -89,10 +89,10 @@ func expectConst(t *testing.T, expr string, env *Env, expected interface{}, expe
 		t.Fatalf("Failed to check expression '%s' (%v)", expr, errs)
 	} else if !aexpr.IsConst() {
 		t.Fatalf("Expression '%s' did not yield a const node(%+v)", expr, aexpr)
-	} else if expectedBigComplex, ok := expected.(*BigComplex); ok {
-		if actual, ok2 := aexpr.Const().Interface().(*BigComplex); !ok2 {
+	} else if expectedNumber, ok := expected.(*ConstNumber); ok {
+		if actual, ok2 := aexpr.Const().Interface().(*ConstNumber); !ok2 {
 			t.Fatalf("Expression '%s' yielded '%v', expected '%v'", expr, aexpr.Const(), expected)
-		} else if !actual.Equals(expectedBigComplex) {
+		} else if !actual.Value.Equals(&expectedNumber.Value) {
 			t.Fatalf("Expression '%s' yielded '%v', expected '%v'", expr, actual, expected)
 		} else if len(aexpr.KnownType()) == 0 {
 			t.Fatalf("Expression '%s' expected to have type '%v'", expr, expectedType)

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -3,6 +3,7 @@ package interactive
 // Utilities for other tests live here
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"reflect"
@@ -116,24 +117,25 @@ func expectCheckError(t *testing.T, expr string, env *Env, errorString ...string
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
 	} else if _, errs := checkExpr(ctx, e, env); errs != nil {
 		var i int
+		out := ""
 		ok := true
 		for i = 0; i < len(errorString); i += 1 {
 			if i > len(errs) {
-				t.Logf("%d. Expected `%v` missing\n", i, errorString[i])
+				out += fmt.Sprintf("%d. Expected `%v` missing\n", i, errorString[i])
 				ok = false
 			} else if errorString[i] == errs[i].Error() {
-				t.Logf("%d. Expected `%v` == `%v`\n", i, errorString[i], errs[i])
+				out += fmt.Sprintf("%d. Expected `%v` == `%v`\n", i, errorString[i], errs[i])
 			} else {
-				t.Logf("%d. Expected `%v` != `%v`\n", i, errorString[i], errs[i])
+				out += fmt.Sprintf("%d. Expected `%v` != `%v`\n", i, errorString[i], errs[i])
 				ok = false
 			}
 		}
 		for ; i < len(errs); i += 1 {
-			t.Logf("%d. Unexpected `%v`\n", i, errs[i])
+			out += fmt.Sprintf("%d. Unexpected `%v`\n", i, errs[i])
 			ok = false
 		}
 		if !ok {
-			t.Fatalf("Wrong check errors for expression '%s'", expr)
+			t.Fatalf("%sWrong check errors for expression '%s'", out, expr)
 		}
 	} else {
 		for i, s := range errorString {

--- a/untypednil.go
+++ b/untypednil.go
@@ -1,0 +1,6 @@
+package interactive
+
+type UntypedNil struct {}
+func (UntypedNil) String() string {
+	return "nil"
+}

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"go/ast"
+	"go/token"
 )
 
 func assignableValue(x reflect.Value, to reflect.Type, xTyped bool) (reflect.Value, error) {
@@ -109,3 +110,11 @@ func expectSingleValue(ctx *Ctx, values []reflect.Value, srcExpr ast.Expr) (refl
 	}
 }
 
+func isBooleanOp(op token.Token) bool {
+	switch op {
+	case token.EQL, token.NEQ, token.LEQ, token.GEQ, token.LSS, token.GTR, token.LAND, token.LOR:
+		return true
+	default:
+		return false
+	}
+}

--- a/util.go
+++ b/util.go
@@ -103,7 +103,7 @@ func expectSingleValue(ctx *Ctx, values []reflect.Value, srcExpr ast.Expr) (refl
 	if len(values) == 0 {
 		return reflect.Value{}, ErrMissingValue{at(ctx, srcExpr)}
 	} else if len(values) != 1 {
-		return reflect.Value{}, ErrMultiInSingleContext{at(ctx, srcExpr), values}
+		return reflect.Value{}, ErrMultiInSingleContext{at(ctx, srcExpr)}
 	} else {
 		return values[0], nil
 	}


### PR DESCRIPTION
This is not my proudest moment. I've gone back and forth between using parts of the go.types library and doing things from scratch. The below mess is what it takes to evaluate binary and unary ops with untyped const operands.

The biggest problem I found with go.types was getting errors to match the format of what's generated by gc. I think clinging to the reference implementation will help give the project a bit of legitimacy if it were ever to see adoption. Consistent error messages help with that.

At this point I wouldn't bother going through reading all the changes. This pull is ridiculously huge.

Where I do want to get your advice though is testing. As you can see checkbinaryexpr_test.go is about 500 lines long. It is essentially a grid test for binary ops, so far for cost types

`(int, rune, float, complex) x (int, rune, float, complex, bool, string, nil)`

However maintaining this is becoming painful. I'm thinking about code gen'ing a test for each `lhs x op x rhs` case. This will become even more extreme for mixed typed untyped operations. The logic for computing these is quite simple, but there are a huge number of corner cases with truncations and overflows for different sizes. I would guess the generated file could be in the order of 10k lines long. What are your thoughts on that approach.

Code gen'ing error messages would also mean that if the errors from gc change, perhaps after a new version, then the changes could be reflected in the tests by just regenerating the test files.

I've been searching for projects that do something similar. The "fmt" package tests are quite involved but usually only loop through one dimension. I haven't found anything specifically that generates test code though.
