### PR TITLE
[r=Rocky] Carl fix demos

### DIFF
--- a/binaryexpr.go
+++ b/binaryexpr.go
@@ -9,10 +9,10 @@ import (
 func evalBinaryExpr(ctx *Ctx, b *BinaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
 	var xx, yy *[]reflect.Value
 	var xtyped, ytyped bool
-	if xx, xtyped, err = EvalExpr(ctx, b.X, env); err != nil {
+	if xx, xtyped, err = EvalExpr(ctx, b.X.(Expr), env); err != nil {
 		return reflect.Value{}, false, err
 	}
-	if yy, ytyped, err = EvalExpr(ctx, b.Y, env); err != nil {
+	if yy, ytyped, err = EvalExpr(ctx, b.Y.(Expr), env); err != nil {
 		return reflect.Value{}, false, err
 	}
 	rtyped = xtyped || ytyped

--- a/callexpr.go
+++ b/callexpr.go
@@ -9,14 +9,14 @@ import (
 )
 
 func evalCallExpr(ctx *Ctx, call *CallExpr, env *Env) (*[]reflect.Value, bool, error) {
-	if t, err := evalType(ctx, call.Fun, env); err == nil {
+	if t, err := evalType(ctx, call.Fun.(Expr), env); err == nil {
 		if v, typed, err := evalCallTypeExpr(ctx, t, call, env); err != nil {
 			return nil, false, err
 		} else {
 			ret := []reflect.Value{v}
 			return &ret, typed, nil
 		}
-	} else if fun, _, err := EvalExpr(ctx, call.Fun, env); err == nil {
+	} else if fun, _, err := EvalExpr(ctx, call.Fun.(Expr), env); err == nil {
 		return evalCallFunExpr(ctx, (*fun)[0], call, env)
 	} else {
 		return nil, false, err
@@ -29,7 +29,7 @@ func evalCallTypeExpr(ctx *Ctx, t reflect.Type, call *CallExpr, env *Env) (refle
 		return r, false, errors.New(fmt.Sprintf("missing argument to conversion to %v", t))
 	} else if len(call.Args) > 1 {
 		return r, false, errors.New(fmt.Sprintf("too many arguments to conversion to %v", t))
-	} else if arg, typed, err := EvalExpr(ctx, call.Args[0], env); err != nil {
+	} else if arg, typed, err := EvalExpr(ctx, call.Args[0].(Expr), env); err != nil {
 		return r, false, err
 	} else if cast, err := assignableValue((*arg)[0], t, typed); err != nil {
 		return r, false, err
@@ -42,7 +42,7 @@ func evalCallFunExpr(ctx *Ctx, fun reflect.Value, call *CallExpr, env *Env) (*[]
 	var err error
 	var v *[]reflect.Value
 	var typed bool
-	if v, typed, err = EvalExpr(ctx, call.Fun, env); v == nil {
+	if v, typed, err = EvalExpr(ctx, call.Fun.(Expr), env); v == nil {
 		return nil, false, nil
 	}
 	if err != nil {
@@ -70,7 +70,7 @@ func evalCallFunExpr(ctx *Ctx, fun reflect.Value, call *CallExpr, env *Env) (*[]
 	// Evaluate each arg
 	for i := range call.Args {
 		var err error
-		args[i], atyped[i], err = EvalExpr(ctx, call.Args[i], env)
+		args[i], atyped[i], err = EvalExpr(ctx, call.Args[i].(Expr), env)
 		if err != nil {
 			return nil, false, err
 		}

--- a/checkbinaryexpr.go
+++ b/checkbinaryexpr.go
@@ -11,10 +11,10 @@ func checkBinaryExpr(ctx *Ctx, binary *ast.BinaryExpr, env *Env) (aexpr *BinaryE
 	aexpr = &BinaryExpr{BinaryExpr: binary}
 
 	var moreErrs []error
-	if aexpr.X, moreErrs = checkExpr(ctx, binary.X, env); moreErrs != nil {
+	if aexpr.X, moreErrs = CheckExpr(ctx, binary.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
-	if aexpr.Y, moreErrs = checkExpr(ctx, binary.Y, env); moreErrs != nil {
+	if aexpr.Y, moreErrs = CheckExpr(ctx, binary.Y, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 

--- a/checkcallexpr.go
+++ b/checkcallexpr.go
@@ -8,12 +8,12 @@ func checkCallExpr(ctx *Ctx, callExpr *ast.CallExpr, env *Env) (aexpr *CallExpr,
 	aexpr = &CallExpr{CallExpr: callExpr}
 
 	var moreErrs []error
-	if aexpr.Fun, moreErrs = checkExpr(ctx, callExpr.Fun, env); moreErrs != nil {
+	if aexpr.Fun, moreErrs = CheckExpr(ctx, callExpr.Fun, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 
 	for i := range callExpr.Args {
-		if aexpr.Args[i], moreErrs = checkExpr(ctx, callExpr.Args[i], env); moreErrs != nil {
+		if aexpr.Args[i], moreErrs = CheckExpr(ctx, callExpr.Args[i], env); moreErrs != nil {
 			errs = append(errs, moreErrs...)
 		}
 	}

--- a/checkcompositelit.go
+++ b/checkcompositelit.go
@@ -13,7 +13,7 @@ func checkCompositeLit(ctx *Ctx, lit *ast.CompositeLit, env *Env) (aexpr *Compos
 	}
 
 	for i := range lit.Elts {
-		if aexpr.Elts[i], moreErrs = checkExpr(ctx, lit.Elts[i], env); moreErrs != nil {
+		if aexpr.Elts[i], moreErrs = CheckExpr(ctx, lit.Elts[i], env); moreErrs != nil {
 			errs = append(errs, moreErrs...)
 		}
 	}

--- a/checkexpr.go
+++ b/checkexpr.go
@@ -8,7 +8,7 @@ import (
 	"go/ast"
 )
 
-func checkExpr(ctx *Ctx, expr ast.Expr, env *Env) (Expr, []error) {
+func CheckExpr(ctx *Ctx, expr ast.Expr, env *Env) (Expr, []error) {
 	switch expr := expr.(type) {
 	case *ast.BadExpr:
 		return &BadExpr{BadExpr: expr}, nil

--- a/checkindexexpr.go
+++ b/checkindexexpr.go
@@ -8,10 +8,10 @@ func checkIndexExpr(ctx *Ctx, index *ast.IndexExpr, env *Env) (aexpr *IndexExpr,
 	aexpr = &IndexExpr{IndexExpr: index}
 
 	var moreErrs []error
-	if aexpr.X, moreErrs = checkExpr(ctx, index.X, env); moreErrs != nil {
+	if aexpr.X, moreErrs = CheckExpr(ctx, index.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
-	if aexpr.Index, moreErrs = checkExpr(ctx, index.Index, env); moreErrs != nil {
+	if aexpr.Index, moreErrs = CheckExpr(ctx, index.Index, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 

--- a/checkkeyvalueexpr.go
+++ b/checkkeyvalueexpr.go
@@ -8,10 +8,10 @@ func checkKeyValueExpr(ctx *Ctx, keyValue *ast.KeyValueExpr, env *Env) (aexpr *K
 	aexpr = &KeyValueExpr{KeyValueExpr: keyValue}
 
 	var moreErrs []error
-	if aexpr.Key, moreErrs = checkExpr(ctx, keyValue.Key, env); moreErrs != nil {
+	if aexpr.Key, moreErrs = CheckExpr(ctx, keyValue.Key, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
-	if aexpr.Value, moreErrs = checkExpr(ctx, keyValue.Value, env); moreErrs != nil {
+	if aexpr.Value, moreErrs = CheckExpr(ctx, keyValue.Value, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 	return aexpr, errs

--- a/checkparenexpr.go
+++ b/checkparenexpr.go
@@ -8,7 +8,7 @@ func checkParenExpr(ctx *Ctx, paren *ast.ParenExpr, env *Env) (aexpr *ParenExpr,
 	aexpr = &ParenExpr{ParenExpr: paren}
 
 	var moreErrs []error
-	if aexpr.X, moreErrs = checkExpr(ctx, paren.X, env); moreErrs != nil {
+	if aexpr.X, moreErrs = CheckExpr(ctx, paren.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 	return aexpr, errs

--- a/checkselectorexpr.go
+++ b/checkselectorexpr.go
@@ -8,7 +8,7 @@ func checkSelectorExpr(ctx *Ctx, selector *ast.SelectorExpr, env *Env) (aexpr *S
 	aexpr = &SelectorExpr{SelectorExpr: selector}
 
 	var moreErrs []error
-	if aexpr.X, moreErrs = checkExpr(ctx, selector.X, env); moreErrs != nil {
+	if aexpr.X, moreErrs = CheckExpr(ctx, selector.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 	return aexpr, errs

--- a/checkunaryexpr.go
+++ b/checkunaryexpr.go
@@ -9,7 +9,7 @@ func checkUnaryExpr(ctx *Ctx, unary *ast.UnaryExpr, env *Env) (aexpr *UnaryExpr,
 	aexpr = &UnaryExpr{UnaryExpr: unary}
 
 	var moreErrs []error
-	if aexpr.X, moreErrs = checkExpr(ctx, unary.X, env); moreErrs != nil {
+	if aexpr.X, moreErrs = CheckExpr(ctx, unary.X, env); moreErrs != nil {
 		errs = append(errs, moreErrs...)
 	}
 

--- a/compositelitexpr.go
+++ b/compositelitexpr.go
@@ -11,7 +11,7 @@ import (
 )
 
 func evalCompositeLit(ctx *Ctx, lit *CompositeLit, env *Env) (*reflect.Value, bool, error) {
-	t, err := evalType(ctx, lit.Type, env)
+	t, err := evalType(ctx, lit.Type.(Expr), env)
 	if err != nil {
 		return nil, true, err
 	}
@@ -75,7 +75,7 @@ func evalCompositeLitArrayOrSlice(ctx *Ctx, t reflect.Type, lit *CompositeLit, e
 
 		// Evaluate and set the element
 		elem := v.Index(int(curKey))
-		if values, typed, err := EvalExpr(ctx, expr, env); err != nil {
+		if values, typed, err := EvalExpr(ctx, expr.(Expr), env); err != nil {
 			return nil, false, err
 		} else if value, err := expectSingleValue(ctx, *values, elt); err != nil {
 			return nil, false, err
@@ -108,7 +108,7 @@ func evalCompositeLitStruct(ctx *Ctx, t reflect.Type, lit *CompositeLit, env *En
 			} else if f := v.FieldByName(k.Name); !f.IsValid() {
 				return &v, true, errors.New(t.Name() + " has no field " + k.Name)
 			} else {
-				fv, ft, err := EvalExpr(ctx, kv.Value, env)
+				fv, ft, err := EvalExpr(ctx, kv.Value.(Expr), env)
 				if err != nil {
 					return &v, true, err
 				} else if fv == nil {
@@ -127,7 +127,7 @@ func evalCompositeLitStruct(ctx *Ctx, t reflect.Type, lit *CompositeLit, env *En
 			} else if _, ok := elt.(*KeyValueExpr); ok {
 				return &v, true, errors.New("Elements are either all key value pairs or not")
 			} else {
-				fv, ft, err := EvalExpr(ctx, elt, env)
+				fv, ft, err := EvalExpr(ctx, elt.(Expr), env)
 				if err != nil {
 					return &v, true, err
 				} else if fv == nil {

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,2 +1,2 @@
 /binaryexpr
-/demo
+/repl

--- a/demo/binaryexpr.go
+++ b/demo/binaryexpr.go
@@ -12,7 +12,9 @@ func expectResult(expr string, env *interactive.Env, expected interface{}) {
 	if e, err := parser.ParseExpr(expr); err != nil {
 		fmt.Printf("Failed to parse expression '%s' (%v)\n", expr, err)
 		return
-	} else if results, _, err := interactive.EvalExpr(ctx, e, env); err != nil {
+	} else if cexpr, errs := interactive.CheckExpr(ctx, e, env); len(errs) != 0 {
+		fmt.Printf("Error checking expression '%s' (%v)\n", expr, errs)
+	} else if results, _, err := interactive.EvalExpr(ctx, cexpr, env); err != nil {
 		fmt.Printf("Error evaluating expression '%s' (%v)\n", expr, err)
 		return
 	} else {

--- a/demo/repl.go
+++ b/demo/repl.go
@@ -47,10 +47,14 @@ func REPL(env *interactive.Env, results *([]interface{})) {
 			if err == io.EOF { break }
 			panic(err)
 		}
-		//line = "func() {" + line + "}"
+		ctx := &interactive.Ctx{line}
 		if expr, err := parser.ParseExpr(line); err != nil {
 			fmt.Printf("parse error: %s\n", err)
-		} else if vals, _, err := interactive.EvalExpr(&interactive.Ctx{line}, expr, env); err != nil {
+		} else if cexpr, errs := interactive.CheckExpr(ctx, expr, env); len(errs) != 0 {
+			for _, cerr := range errs {
+				fmt.Printf("%v\n", cerr)
+			}
+		} else if vals, _, err := interactive.EvalExpr(ctx, cexpr, env); err != nil {
 			fmt.Printf("eval error: %s\n", err)
 		} else if vals == nil {
 			fmt.Printf("nil\n")

--- a/expr.go
+++ b/expr.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-
-	"go/ast"
 )
 
-func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env) (*[]reflect.Value, bool, error) {
+func EvalExpr(ctx *Ctx, expr Expr, env *Env) (*[]reflect.Value, bool, error) {
 	switch node := expr.(type) {
 	case *Ident:
 		v, typed, err := evalIdentExpr(ctx, node, env)
@@ -26,7 +24,7 @@ func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env) (*[]reflect.Value, bool, error)
 		v, typed, err := evalCompositeLit(ctx, node, env)
 		return &[]reflect.Value{*v}, typed, err
 	case *ParenExpr:
-		return EvalExpr(ctx, node.X, env)
+		return EvalExpr(ctx, node.X.(Expr), env)
 	case *SelectorExpr:
 		v, typed, err := evalSelectorExpr(ctx, node, env)
 		if v == nil {
@@ -58,7 +56,7 @@ func EvalExpr(ctx *Ctx, expr ast.Expr, env *Env) (*[]reflect.Value, bool, error)
 	return &[]reflect.Value{reflect.ValueOf("Alice")}, true, nil
 }
 
-func evalType(ctx *Ctx, expr ast.Expr, env *Env) (reflect.Type, error) {
+func evalType(ctx *Ctx, expr Expr, env *Env) (reflect.Type, error) {
 	switch node := expr.(type) {
 	case *Ident:
 		if t, ok := env.Types[node.Name]; ok {

--- a/indexexpr.go
+++ b/indexexpr.go
@@ -8,7 +8,7 @@ import (
 )
 
 func evalIndexExpr(ctx *Ctx, index *IndexExpr, env *Env) (*reflect.Value, bool, error) {
-	xs, _, err := EvalExpr(ctx, index.X, env)
+	xs, _, err := EvalExpr(ctx, index.X.(Expr), env)
 	if err != nil {
 		return nil, false, err
 	} else if xs == nil {
@@ -47,7 +47,7 @@ func evalIndexExprInt(ctx *Ctx, x reflect.Value, intExpr ast.Expr, env *Env) (*r
 }
 
 func evalIntIndex(ctx *Ctx, intExpr ast.Expr, env *Env, containerType reflect.Type) (int, error) {
-	if is, typed, err := EvalExpr(ctx, intExpr, env); err != nil {
+	if is, typed, err := EvalExpr(ctx, intExpr.(Expr), env); err != nil {
 		return -1, err
 	} else if is == nil {
 		// XXX temporary error until typed evaluation of nil

--- a/interactive_test.go
+++ b/interactive_test.go
@@ -28,7 +28,7 @@ func expectResults(t *testing.T, expr string, env *Env, expected *[]interface{})
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
-	} else if aexpr, errs := checkExpr(ctx, e, env); errs != nil {
+	} else if aexpr, errs := CheckExpr(ctx, e, env); errs != nil {
 		t.Fatalf("Failed to check expression '%s' (%v)", expr, errs)
 	} else if results, _, err := EvalExpr(ctx, aexpr, env); err != nil {
 		t.Fatalf("Error evaluating expression '%s' (%v)", expr, err)
@@ -55,7 +55,7 @@ func expectError(t *testing.T, expr string, env *Env, errorString string) {
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
-	} else if aexpr, errs := checkExpr(ctx, e, env); errs != nil {
+	} else if aexpr, errs := CheckExpr(ctx, e, env); errs != nil {
 		// TODO handle check errors
 		panic("No tests should fail here (yet)")
 	} else if _, _, err := EvalExpr(ctx, aexpr, env); err == nil {
@@ -71,7 +71,7 @@ func expectFail(t *testing.T, expr string, env *Env) {
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
-	} else if aexpr, errs := checkExpr(ctx, e, env); errs != nil {
+	} else if aexpr, errs := CheckExpr(ctx, e, env); errs != nil {
 		// TODO handle check errors
 		panic("No tests should fail here (yet)")
 	} else if _, _, err := EvalExpr(ctx, aexpr, env); err == nil {
@@ -86,7 +86,7 @@ func expectConst(t *testing.T, expr string, env *Env, expected interface{}, expe
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
-	} else if aexpr, errs := checkExpr(ctx, e, env); errs != nil {
+	} else if aexpr, errs := CheckExpr(ctx, e, env); errs != nil {
 		t.Fatalf("Failed to check expression '%s' (%v)", expr, errs)
 	} else if !aexpr.IsConst() {
 		t.Fatalf("Expression '%s' did not yield a const node(%+v)", expr, aexpr)
@@ -115,7 +115,7 @@ func expectCheckError(t *testing.T, expr string, env *Env, errorString ...string
 	ctx := &Ctx{expr}
 	if e, err := parser.ParseExpr(expr); err != nil {
 		t.Fatalf("Failed to parse expression '%s' (%v)", expr, err)
-	} else if _, errs := checkExpr(ctx, e, env); errs != nil {
+	} else if _, errs := CheckExpr(ctx, e, env); errs != nil {
 		var i int
 		out := "\n"
 		ok := true

--- a/selectorexpr.go
+++ b/selectorexpr.go
@@ -9,7 +9,7 @@ import (
 func evalSelectorExpr(ctx *Ctx, selector *SelectorExpr, env *Env) (*reflect.Value, bool, error) {
 	var err error
 	var x *[]reflect.Value
-	if x, _, err = EvalExpr(ctx, selector.X, env); err != nil {
+	if x, _, err = EvalExpr(ctx, selector.X.(Expr), env); err != nil {
 		return nil, true, err
 	}
 	sel   := selector.Sel.Name

--- a/unaryexpr.go
+++ b/unaryexpr.go
@@ -9,7 +9,7 @@ import (
 func evalUnaryExpr(ctx *Ctx, b *UnaryExpr, env *Env) (r reflect.Value, rtyped bool, err error) {
 	var xx *[]reflect.Value
 	var xtyped bool
-	if xx, xtyped, err = EvalExpr(ctx, b.X, env); err != nil {
+	if xx, xtyped, err = EvalExpr(ctx, b.X.(Expr), env); err != nil {
 		return reflect.Value{}, false, err
 	}
 	rtyped = xtyped


### PR DESCRIPTION
REPL may be a bit unstable for a little while as the checker comes into action.

The expression is checked, but the computed constants aren't used. You'll still get nice errors when mixing types though.

```
go> 1 + "abc"
cannot convert "abc" to type int
invalid operation: 1 + "abc" (mismatched types int and string)
```
